### PR TITLE
Using language code in Wollok-TS

### DIFF
--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -115,28 +115,24 @@ class Object {
    * Answers object identity of a Wollok object, represented by
    * a unique number in Wollok environment 
    */
-  // TODO: Move to mirror?
   method identity() native
   
   /** 
    * Answers a list of instance variables for this Wollok object
    * @private - needed by wollok-xtext implementation
    */
-  // TODO: Move to mirror?
   method instanceVariables() native
   
   /** 
    * Retrieves a specific variable. Expects a name
    * @private - needed by wollok-xtext implementation
    */
-  // TODO: Move to mirror?
   method instanceVariableFor(name) native
   
   /**
    * Accesses a variable by name, in a reflexive way.
    * @private - needed by wollok-xtext implementation 
    */
-  // TODO: Move to mirror?
   method resolve(name) native
   
   /** Object description in english/spanish/... (depending on i18n configuration)
@@ -147,14 +143,12 @@ class Object {
    *
    * @private
    */
-  // TODO: Move to mirror?
   method kindName() native
 
   /** 
    * Full name of Wollok object class
    * @private 
    */
-  // TODO: Move to mirror?
   method className() native
   
   /**
@@ -249,8 +243,6 @@ class Object {
     * internal method: generates a does not understand message
     * parametersSize must be an integer value
     */
-  // TODO: Does this really need to be a native?
-  // TODO: Move to mirror?
   method generateDoesNotUnderstandMessage(target, messageName, parametersSize) native
   
   /** Builds an exception with a message */    
@@ -648,7 +640,6 @@ class Collection {
    *      [1, 3, 5].findOrElse({ number => number.even() }, { 6.max(4) }) => Answers 6
    *      [].findOrElse({ number => number.even() }, { false })           => Answers false
    */
-  // TODO: Does this really need to be a native?
   method findOrElse(predicate, continuation) native
 
   /**

--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -109,6 +109,10 @@ class StackTraceElement {
  */
 class Object {
 
+  constructor() {
+    self.initialize()
+  }
+
   method initialize() { }
 
   /** 

--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -944,7 +944,7 @@ class Collection {
    */
   method join(separator) =
     if (self.isEmpty()) ""
-    else self.subList(1).fold({ string, element => string + separator + element.toString() }, self.first().toString())
+    else self.subList(1).fold(self.first().toString(), { string, element => string + separator + element.toString() })
   
   /**
    * Answers the concatenated string representation of the elements in the given set

--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -944,7 +944,7 @@ class Collection {
    */
   method join(separator) =
     if (self.isEmpty()) ""
-    else self.subList(1).fold({ string, element => string + separator + element.toString() }, self.first.toString())
+    else self.subList(1).fold({ string, element => string + separator + element.toString() }, self.first().toString())
   
   /**
    * Answers the concatenated string representation of the elements in the given set

--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -109,6 +109,8 @@ class StackTraceElement {
  */
 class Object {
 
+  method initialize() { }
+
   /** 
    * Answers object identity of a Wollok object, represented by
    * a unique number in Wollok environment 
@@ -2354,7 +2356,7 @@ class Range {
     * Instantiates a Range. 
     * Both start and end must be integer values.
     */
-  method initialize() {
+  override method initialize() {
 		start = start.truncate(0)
 		end = end.truncate(0)
     if (step == null) {
@@ -2533,8 +2535,6 @@ class Range {
  */
 class Closure {
 
-  method initialize() native
-
   /** Evaluates this closure passing its parameters
    *
    * Example: 
@@ -2572,7 +2572,7 @@ class Date {
   const property year
   
   /** @private */
-  method initialize() native
+  override method initialize() native
   
   /** String representation of a date */
   override method toString() = self.toSmartString(false) 

--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -1475,6 +1475,8 @@ class List inherits Collection {
  */
 class Dictionary {
 
+  override method initialize() native
+
   /**
    * Adds or updates a value based on a key.
    * If key is not present, a new value is added. 
@@ -2371,6 +2373,8 @@ class Range {
     * Both start and end must be integer values.
     */
   override method initialize() {
+    super()
+
 		start = start.truncate(0)
 		end = end.truncate(0)
     if (step == null) {

--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -153,7 +153,7 @@ class Object {
    * Tells whether self object is "equal" to the given object
    * The default behavior compares them in terms of identity (===)
    */
-  method ==(other) = other != null && self === other 
+  method ==(other) = self === other 
   
   /** Tells whether self object is not equal to the given one */
   method !=(other) = ! (self == other)

--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -115,24 +115,28 @@ class Object {
    * Answers object identity of a Wollok object, represented by
    * a unique number in Wollok environment 
    */
+  // TODO: Move to mirror?
   method identity() native
   
   /** 
    * Answers a list of instance variables for this Wollok object
    * @private - needed by wollok-xtext implementation
    */
+  // TODO: Move to mirror?
   method instanceVariables() native
   
   /** 
    * Retrieves a specific variable. Expects a name
    * @private - needed by wollok-xtext implementation
    */
+  // TODO: Move to mirror?
   method instanceVariableFor(name) native
   
   /**
    * Accesses a variable by name, in a reflexive way.
    * @private - needed by wollok-xtext implementation 
    */
+  // TODO: Move to mirror?
   method resolve(name) native
   
   /** Object description in english/spanish/... (depending on i18n configuration)
@@ -143,12 +147,14 @@ class Object {
    *
    * @private
    */
+  // TODO: Move to mirror?
   method kindName() native
 
   /** 
    * Full name of Wollok object class
    * @private 
    */
+  // TODO: Move to mirror?
   method className() native
   
   /**
@@ -243,6 +249,8 @@ class Object {
     * internal method: generates a does not understand message
     * parametersSize must be an integer value
     */
+  // TODO: Does this really need to be a native?
+  // TODO: Move to mirror?
   method generateDoesNotUnderstandMessage(target, messageName, parametersSize) native
   
   /** Builds an exception with a message */    
@@ -640,6 +648,7 @@ class Collection {
    *      [1, 3, 5].findOrElse({ number => number.even() }, { 6.max(4) }) => Answers 6
    *      [].findOrElse({ number => number.even() }, { false })           => Answers false
    */
+  // TODO: Does this really need to be a native?
   method findOrElse(predicate, continuation) native
 
   /**
@@ -1187,7 +1196,7 @@ class List inherits Collection {
    */
   override method anyOne() {
     self.validateNotEmpty("anyOne")    
-    return self.get(0.randomUpTo(self.size()))
+    return self.get(0.randomUpTo(self.size()).truncate(0))
   }
   
   /**

--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -109,10 +109,6 @@ class StackTraceElement {
  */
 class Object {
 
-  constructor() {
-    self.initialize()
-  }
-
   method initialize() { }
 
   /** 

--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -942,13 +942,15 @@ class Collection {
    * Answers the concatenated string representation of the elements in the given set.
    * You can pass an optional character as an element separator (default is ",")
    */
-  method join(separator)
+  method join(separator) =
+    if (self.isEmpty()) ""
+    else self.subList(1).fold({ string, element => string + separator + element.toString() }, self.first.toString())
   
   /**
    * Answers the concatenated string representation of the elements in the given set
    * with default element separator (",")
    */
-  method join()
+  method join() = self.join(",")
 
 }
 

--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -1080,6 +1080,9 @@ class Set inherits Collection {
    *     set.add(2)   => set = #{2, 3}, second add produces no effect   
    */
   override method add(element) native
+
+  /** @private */
+  method unsafeAdd(element) native
   
   /**
    * Removes the specified element from this set if it is present.

--- a/test/sanity/collections/collectionTestCase.wtest
+++ b/test/sanity/collections/collectionTestCase.wtest
@@ -466,7 +466,6 @@ describe "Collection test case" {
     assert.equals([2, 10], numbers.subList(1,2) )
     assert.equals([22, 2], numbers.subList(0,1) )
     assert.equals([22, 2, 10], numbers.subList(0,6) )
-    // TODO: ?
     // fixed in lang.wlk but need to override lang.wlk definition
     // assert.equals([], numbers.subList(5,6) )
   }

--- a/test/sanity/collections/collectionTestCase.wtest
+++ b/test/sanity/collections/collectionTestCase.wtest
@@ -461,6 +461,7 @@ describe "Collection test case" {
     assert.equals([2, 10], numbers.subList(1,2) )
     assert.equals([22, 2], numbers.subList(0,1) )
     assert.equals([22, 2, 10], numbers.subList(0,6) )
+    // TODO: ?
     // fixed in lang.wlk but need to override lang.wlk definition
     // assert.equals([], numbers.subList(5,6) )
   }

--- a/test/sanity/collections/collectionTestCase.wtest
+++ b/test/sanity/collections/collectionTestCase.wtest
@@ -443,15 +443,20 @@ describe "Collection test case" {
   
   
   test "sortedBy" {
-    const numbers = [22, 2, 10]
-    var numbersSet = numbers.asSet()
-    assert.equals([22,10,2], numbers.sortedBy({a,b=>a>b}))
-    assert.equals([22,10,2], numbersSet.sortedBy({a,b=>a>b}))
-    assert.equals([2,10,22], numbers.sortedBy({a,b=>a<b}))
-    assert.equals([2,10,22], numbersSet.sortedBy({a,b=>a<b}))
-    assert.equals([5], [5].sortedBy({a,b=>a>b}))
-    assert.equals([5], #{5}.sortedBy({a,b=>a>b}))
-    assert.equals([], [].sortedBy({a,b=>a>b}))
+    const numbers = [22, 2, 10, 5]
+    const numbersSet = numbers.asSet()
+
+    assert.equals([22, 10, 5, 2], numbers.sortedBy{ a, b => a > b })
+    assert.equals([22, 10, 5, 2], numbersSet.sortedBy{ a, b => a > b })
+    
+    assert.equals([2, 5, 10, 22], numbers.sortedBy{ a, b => a < b })
+    assert.equals([2, 5, 10, 22], numbersSet.sortedBy{ a, b => a < b })
+    
+    assert.equals([5], [5].sortedBy{ a, b => a > b })
+    assert.equals([5], #{5}.sortedBy{ a, b => a > b })
+    
+    assert.equals([], [].sortedBy{ a, b => a > b })
+    assert.equals([], #{}.sortedBy{ a, b => a > b })
   }  
   
 

--- a/test/sanity/exceptionTestCase/assertThrowsExceptionFailing.wtest
+++ b/test/sanity/exceptionTestCase/assertThrowsExceptionFailing.wtest
@@ -2,7 +2,6 @@ test "Assert throws exception failing" {
 	
 	var a = 0
 	assert.throwsExceptionLike(
-		// TODO NicoS: es posible hacer que wollok-ts nos dé el código acá?
 		new AssertionException(message = "Block { a + 1 } should have failed"),
 		{ assert.throwsException({ a + 1 }) }
 	)

--- a/test/sanity/exceptionTestCase/testMessageNotUnderstoodWithParams.wtest
+++ b/test/sanity/exceptionTestCase/testMessageNotUnderstoodWithParams.wtest
@@ -1,5 +1,5 @@
 class A { 
-	method m1() { throw new Exception("hello you see") }
+	method m1() { throw new Exception() }
 }
 			
 test "Test message not understood with params" {

--- a/test/sanity/list.wtest
+++ b/test/sanity/list.wtest
@@ -109,8 +109,8 @@ describe "List tests"{
 	}	
 
 	test "without duplicates" {
-		assert.equals([1, 3, 1, 5, 1, 3, 2, 5].withoutDuplicates(), [1, 3, 5, 2])
-		assert.equals([1, 3, 5, 2].withoutDuplicates(), [1, 3, 5, 2])
+		assert.equals([1, 3, 5, 2], [1, 3, 1, 5, 1, 3, 2, 5].withoutDuplicates())
+		assert.equals([1, 3, 5, 2], [1, 3, 5, 2].withoutDuplicates())
 	}	
 	
 	test "sortBy" {

--- a/test/sanity/null.wtest
+++ b/test/sanity/null.wtest
@@ -71,8 +71,7 @@ describe "Null Test Case"{
 	
 			assert.notThat(8 == null)
 			assert.notThat("pepe" == null)
-			// TODO: ?
-			//assert.notThat(false == null)
+			assert.notThat(false == null)
 			assert.notThat(2.0 == null)
 			assert.notThat(1..2 == null)
 			assert.notThat([1,2,3] == null)

--- a/test/sanity/null.wtest
+++ b/test/sanity/null.wtest
@@ -71,6 +71,7 @@ describe "Null Test Case"{
 	
 			assert.notThat(8 == null)
 			assert.notThat("pepe" == null)
+			// TODO: ?
 			//assert.notThat(false == null)
 			assert.notThat(2.0 == null)
 			assert.notThat(1..2 == null)

--- a/test/sanity/range.wtest
+++ b/test/sanity/range.wtest
@@ -77,7 +77,7 @@ describe "Range Test Case"{
 
 	test "map" {
 		 
-		var range = 0 .. 5 
+		var range = 0 .. 5
 		assert.that([0, 2, 4, 6, 8, 10] == range.map({ elem => elem * 2}))
 		  	
 	}


### PR DESCRIPTION
These changes where product of integrating Wollok-ts to this repo's WRE.

Most changes are clean-up, or adding small details or comments to tests. I tried to impose as little as possible and not force any interface changes on the language but, if any of these changes look bad to you, let's discuss them.

We still have three natives that cannot be implemented in ts and are currently just stubbed, all of them in Object:
    instanceVariables(), instanceVariableFor(name) and resolve(name)

The main cause for this is that I could not find a class in wollok.lang to represent an instance variable (that seems to only require name() and valueToSmartString() ). This has no mayor impact, besides the toString not being the same (but, as I understood, we might change it anyway).

So, to fix this, we would need to either drop the current toString or add a class InstanceVariable somewhere.