### PR TITLE
Default game configuration

### DIFF
--- a/src/wollok/game.wlk
+++ b/src/wollok/game.wlk
@@ -4,6 +4,16 @@ import wollok.vm.runtime
   * Wollok Game main object 
   */
 object game {
+
+  override method initialize() {
+    super()
+    
+    self.title("Wollok Game")
+    self.width(5)
+    self.height(5)
+    self.cellSize(50)
+    self.ground("ground.png")
+    }
   
   /**
    * Adds an object to the board for drawing it.

--- a/test/sanity/game/game.wtest
+++ b/test/sanity/game/game.wtest
@@ -115,4 +115,10 @@ describe "Game" {
     game.cellSize(10)
   }
 
+  test "game should initialize with default values"{
+    assert.equals("Wollok Game", game.title())
+    assert.equals(5, game.width())
+    assert.equals(5, game.height())
+  }
+
 }


### PR DESCRIPTION
Resolves #69 

* Setie valores default del game segun los valores [en este test](https://github.com/uqbar-project/wollok/blob/b5a48438ebe48629ecff3ef402aa208e3510b8a1/org.uqbar.project.wollok.tests/src/org/uqbar/project/wollok/tests/game/GameboardTest.xtend#L52-L59).

En el test no se checkea por `ground` o por el `cellSize` porque ahora el game no tiene getters para esos atributos. Tambien note que esto ahora no andaría en ts porque _creo_ que no esta implementado el metodo `doCellSize` en ts.