### PR TITLE
Changing constructor calls without named parameters

### DIFF
--- a/src/wollok/lib.wlk
+++ b/src/wollok/lib.wlk
@@ -110,16 +110,16 @@ object assert {
    * Otherwise an exception is thrown.
    *
    * Examples:
-   *    assert.throwsExceptionLike(new BusinessException("hola"), 
-   *            { => throw new BusinessException("hola") } 
+   *    assert.throwsExceptionLike(new BusinessException(message = "hola"), 
+   *            { => throw new BusinessException(message = "hola") } 
    *            => Works! Exception class and message both match.
    *
-   *    assert.throwsExceptionLike(new BusinessException("chau"),
-   *            { => throw new BusinessException("hola") } 
+   *    assert.throwsExceptionLike(new BusinessException(message = "chau"),
+   *            { => throw new BusinessException(message = "hola") } 
    *            => Doesn't work. Exception class matches but messages are different.
    *
-   *    assert.throwsExceptionLike(new OtherException("hola"),
-   *            { => throw new BusinessException("hola") } 
+   *    assert.throwsExceptionLike(new OtherException(message = "hola"),
+   *            { => throw new BusinessException(message = "hola") } 
    *            => Doesn't work. Messages matches but they are instances of different exceptions.
    */   
   method throwsExceptionLike(exceptionExpected, block) {
@@ -167,13 +167,13 @@ object assert {
    * Otherwise an exception is thrown.
    *
    * Examples:
-   *    assert.throwsExceptionWithType(new BusinessException("hola"),{ => throw new BusinessException("hola") } 
+   *    assert.throwsExceptionWithType(new BusinessException(message = "hola"),{ => throw new BusinessException(message = "hola") } 
    *          => Works! Both exceptions are instances of the same class.
    *
-   *    assert.throwsExceptionWithType(new BusinessException("chau"),{ => throw new BusinessException("hola") } 
+   *    assert.throwsExceptionWithType(new BusinessException(message = "chau"),{ => throw new BusinessException(message = "hola") } 
    *          => Works again! Both exceptions are instances of the same class.
    *
-   *    assert.throwsExceptionWithType(new OtherException("hola"),{ => throw new BusinessException("hola") } 
+   *    assert.throwsExceptionWithType(new OtherException(message = "hola"),{ => throw new BusinessException(message = "hola") } 
    *          => Doesn't work. Exception classes differ although they contain the same message.
    */     
   method throwsExceptionWithType(exceptionExpected, block) {
@@ -196,13 +196,13 @@ object assert {
    * returning the result.
    *
    * Examples:
-   *    assert.throwsExceptionByComparing({ => throw new BusinessException("hola"),{ex => "hola" == ex.message()}} 
+   *    assert.throwsExceptionByComparing({ => throw new BusinessException(message = "hola"), { ex => "hola" == ex.message()}} 
    *          => Works!.
    *
-   *    assert.throwsExceptionByComparing({ => throw new BusinessException("hola"),{ex => new BusinessException("lele").className() == ex.className()} } 
+   *    assert.throwsExceptionByComparing({ => throw new BusinessException(message = "hola"), { ex => new BusinessException(message = "lele").className() == ex.className()} } 
    *          => Works again!
    *
-   *    assert.throwsExceptionByComparing({ => throw new BusinessException("hola"),{ex => "chau!" == ex.message()} } 
+   *    assert.throwsExceptionByComparing({ => throw new BusinessException(message = "hola"), { ex => "chau!" == ex.message()} } 
    *          => Doesn't work. The block evaluation resolves to a false value.
    */    
   method throwsExceptionByComparing(block, comparison){

--- a/test/sanity/language/exceptions/catchInShortcutMethod.wtest
+++ b/test/sanity/language/exceptions/catchInShortcutMethod.wtest
@@ -5,7 +5,7 @@
 object cuenta {
   method sacar(c) = try { 
     if (c > 0)
-      throw new Exception("saldo insuficiente") 
+      throw new Exception(message = "saldo insuficiente") 
     else
       19
   } catch e {

--- a/test/sanity/language/exceptions/catchingErrors.wtest
+++ b/test/sanity/language/exceptions/catchingErrors.wtest
@@ -5,7 +5,7 @@
 object cuenta {
   method sacar(monto) {
     try {
-      if (monto > 0) throw new Exception("saldo insuficiente")
+      if (monto > 0) throw new Exception(message = "saldo insuficiente")
       return 19
     } 
     catch e {

--- a/test/sanity/language/initialization/namedParametersBadDefinitions.wtest
+++ b/test/sanity/language/initialization/namedParametersBadDefinitions.wtest
@@ -6,7 +6,7 @@ class Ave {
 	var energia
 	var edad = 10
 	method cumplirAnios() {
-		edad++
+    edad += 1
 	}
 	method volar() { energia = energia - 10 }
 }

--- a/test/sanity/mixins/mixinAtInstantiation.wtest
+++ b/test/sanity/mixins/mixinAtInstantiation.wtest
@@ -37,15 +37,15 @@ mixin Attacks {
 }
 
 test "single mixin at instantiation time" {
-  const warrior = new Warrior() with Energy
+  const warrior = object inherits Warrior mixed with Energy { }
   assert.equals(100, warrior.energy())
 }
 
 test "multiple mixins at instantiation time" {
-  const warrior1 = new Warrior() with Attacks with Energy2 with GetsHurt
+  const warrior1 = object inherits Warrior mixed with Attacks and Energy2 and GetsHurt { }
   assert.equals(100, warrior1.energy())
 
-  const warrior2 = new Warrior() with Attacks with Energy2 with GetsHurt
+  const warrior2 = object inherits Warrior mixed with Attacks and Energy2 and GetsHurt { }
   assert.equals(100, warrior2.energy())
 
   warrior1.attack(warrior2)

--- a/test/sanity/mixins/mixins.wtest
+++ b/test/sanity/mixins/mixins.wtest
@@ -32,7 +32,7 @@ class C mixed with M1 and M2 {
 describe "mixins" {
 
   test "single mixin at instantiation time" {
-    const warrior = new Warrior() with Energy
+    const warrior = object inherits Warrior mixed with Energy { }
     assert.equals(100, warrior.energy())
   }
 

--- a/test/sanity/testing/tests/testingExceptions.wtest
+++ b/test/sanity/testing/tests/testingExceptions.wtest
@@ -63,7 +63,7 @@ describe "testing exceptions" {
 
   test "use throwsExceptionWithMessage: expecting a message but getting other, should fail" {
     try {
-      assert.throwsExceptionWithMessage("hola!", { => throw new BusinessException("Jamaica") })
+      assert.throwsExceptionWithMessage("hola!", { => throw new BusinessException(message = "Jamaica") })
       assert.fail("Should have thrown an exception in throwsExceptionWithMessage getting other message")
     }
     catch ex {


### PR DESCRIPTION
Le hice una pasada por todo lo que fuera `new ` con espacio y me dio 102 archivos y 589 casos. Detecté los ejemplos y los corregí, fijate si están bien porque así genero un PR en Wollok Xtext para que quede reflejado bien en la versión de este cuatrimestre.