### PR TITLE
Adding new test with describe having a local variable in init method

### DIFF
--- a/test/sanity/testing/describe/initializeMethod.wtest
+++ b/test/sanity/testing/describe/initializeMethod.wtest
@@ -58,3 +58,16 @@ describe "const references cannot be additionally assigned in a test initializat
     assert.equals(1, uno)
   }
 }
+
+describe "describe can have local variables in init method" {
+  var valor = 0
+
+  method initialize() {
+    const numero = 5
+    valor = numero * 2
+  }
+
+  test "el doble de un número se calcula correctamente" {
+    assert.equals(10, valor)
+  }
+}


### PR DESCRIPTION
Asociado al issue original https://github.com/uqbar-project/wollok/issues/1638, me di cuenta de que en ningún test creábamos una referencia local dentro de un método initialize de un describe. Encontré un bug en Wollok Xtext y me pareció importante que haya al menos un test que pruebe esa construcción.
