### PR TITLE
Collection builder

### DIFF
--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -929,6 +929,15 @@ class Collection {
 }
 
 /**
+* Builder object for collections.
+* It compensates for the lack of vararg constructors.
+*/
+object collection {
+  method list(elements...) = elements
+  method set(elements...) = elements.asSet()
+}
+
+/**
  *
  * A collection that contains no duplicate elements.
  * It models the mathematical set abstraction.


### PR DESCRIPTION
Buenas,

Desde que sacamos los constructores tenemos que hacer medio una chanchada con los literales de colecciones porque no tenemos ningún mecanismo simple para crear una lista o un set a partir de N miembros (que no requiera usar los literales).

Este objeto me permitiría hacer una limpieza importante de algo feote y creo que no le jode a nadie... Los alumnos no necesitan saber que existe y a mi me haría muy feliz.

Si los nombres no les gustan son negociables. Estaba entre esto y dos objetos `list` y `set` que entienda un mensaje `from(elements...)`. Sinceramente, como es para uso interno, no me importa mucho cuál quede.