### PR TITLE
Adding native to initialize exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, the Wollok language does not adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). 
 Hopefully, we will be able to do that in the near future.
 
+## v3.0.1
+- Exceptions have an `initialize` native method.
+
+## v3.0.0
+- Dropping Constructors in favor of named instantiation.
+- Dropping Fixtures in favor of `initialize` methods in Describes.
+- New syntax for supertype linearization.
 
 ## v2.1.0
 - Many Wollok Game changes for web implementation.

--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -12,6 +12,8 @@ class Exception {
   /** specified cause */
   const property cause = null
 
+  override method initialize() native
+
   /** Prints this exception and its backtrace to the console */
   method printStackTrace() { self.printStackTrace(console) }
 


### PR DESCRIPTION
Hi.

I'm working in improving the log info so we can better trace errors from the game engine on the browser. To do that, I need a place to initialize exceptions...

I added a native `Exception.initialize()` method so we can override the info there. This should have little impact in other implementations (they can just add an empty native), but my plan is to generate a new v`3.0.1` release of the language for this, so we don't need to do this in the xtext implementation if we don't want to.

Already updated the changelog.