### PR TITLE
Fix for faster dictionary implementation

### DIFF
--- a/test/sanity/collections/dictionaryTestCase.wtest
+++ b/test/sanity/collections/dictionaryTestCase.wtest
@@ -77,14 +77,14 @@ describe "dictionary test case" {
     const mapa = new Dictionary()
     mapa.put(4, "2142-5980")
     mapa.put(9, "5302-6617")
-    assert.equals(mapa.keys(), [4, 9])
+    assert.equals(mapa.keys().sortedBy { a, b => a < b }, [4, 9])
   }
 
   test "values" {
     const mapa = new Dictionary()
     mapa.put("2142-5980", 4)
     mapa.put("5302-6617", 9)
-    assert.equals(mapa.values(), [4, 9])
+    assert.equals(mapa.values().sortedBy { a, b => a < b }, [4, 9])
   }
 
   test "forEach" {


### PR DESCRIPTION
Este test está asumiendo que el diccionario mantiene las claves y valores en el orden en que se insertaron. Eso no permite que lo implementemos con Sets o hash buckets.

En todo caso, no creo con que estemos contando con que el diccionario esté ordenado (ningún lenguaje que yo conozca garantiza eso) y más bien lo que pasa es que el test está medio acoplado a la implementación actual.

En fin, este cambio debería hacer que el test pase para cualquier implementación y creo que mantiene el espiritu original.