### PR TITLE
Tests for position precedence

### DIFF
--- a/test/sanity/game/game.wtest
+++ b/test/sanity/game/game.wtest
@@ -14,8 +14,10 @@ object quantumSuperposition {
   method position() = game.at(3, 3)
 }
 
-object positionable {
-  var property position = game.at(5, 3)
+object inamovible {
+  var position = game.at(5, 3)
+
+  method getPosition() = position
 }
 
 /**
@@ -137,8 +139,8 @@ describe "Game" {
   }
 
   test "addVisualIn should not change an objects position attribute" {
-    game.addVisualIn(positionable, game.at(2, 2))
-    assert.equals(game.at(5, 3), positionable.position())
+    game.addVisualIn(inamovible, game.at(2, 2))
+    assert.equals(game.at(5, 3), inamovible.getPosition())
   }
 
 }

--- a/test/sanity/game/game.wtest
+++ b/test/sanity/game/game.wtest
@@ -8,6 +8,16 @@ import wollok.game.*
 object myVisual { }
 class Visual { }
 
+object quantumSuperposition {
+  var position = game.at(2, 4)
+
+  method position() = game.at(3, 3)
+}
+
+object positionable {
+  var property position = game.at(5, 3)
+}
+
 /**
   * Tests
   */
@@ -119,6 +129,16 @@ describe "Game" {
     assert.equals("Wollok Game", game.title())
     assert.equals(5, game.width())
     assert.equals(5, game.height())
+  }
+
+  test "method position should have a higher priority than the atribute position" {
+    game.addVisual(quantumSuperposition)
+    assert.equals([quantumSuperposition], game.getObjectsIn(game.at(3, 3)))
+  }
+
+  test "addVisualIn should not change an objects position attribute" {
+    game.addVisualIn(positionable, game.at(2, 2))
+    assert.equals(game.at(5, 3), positionable.position())
   }
 
 }


### PR DESCRIPTION
Related: https://github.com/uqbar-project/wollok-run-client/pull/64

Agregamos dos tests:
- Uno para verificar que el mensaje position tiene mayor precedencia que el atributo del objeto.
- Otro para asegurarnos de no pisar el atributo preexistente en un objeto si se hace un addVisualIn.

Queda pendiente definir qué sucede cuando hago `addVisualIn` de un objeto que tiene el mensaje `position()`.