### PR TITLE
Test-friendly sounds

### DIFF
--- a/test/sanity/game/sounds.wtest
+++ b/test/sanity/game/sounds.wtest
@@ -21,10 +21,6 @@ describe "sound tests" {
     assert.throwsException { => sound.volume(-3) }
   }
 
-  test "a sound cannot be played if game has not started" {
-    assert.throwsException { => sound.play() }
-  }
-
   test "sound cannot be paused if it has not been played" {
     assert.throwsException { => sound.pause() }
   }


### PR DESCRIPTION
In order to make sounds test-friendly, [this validation](https://github.com/uqbar-project/wollok-language/blob/f7a1e12042027d51632d17f1c9c5d236701195e0/test/sanity/game/sounds.wtest#L24-L26) is no longer needed.

Related to [this issue](https://github.com/uqbar-project/wollok/issues/1896) and [this other one](https://github.com/uqbar-project/wollok-ts/issues/95).


