### PR TITLE
Empty list tests

### DIFF
--- a/test/sanity/collections/list.wtest
+++ b/test/sanity/collections/list.wtest
@@ -304,6 +304,14 @@ describe "List tests" {
   test "head" {
     assert.equals(1, [1, 2, 3].head())
   }
+  
+  test "head of an empty list should fail" {
+  	assert.throwsException({[].head()})
+  }
+  
+  test "last of an empty list should fail" {
+  	assert.throwsException({[].last()})
+  }
 
   test "addAll" {
     const unos = [1,2,3,4]


### PR DESCRIPTION
Agregamos algunos tests relacionado a los cambios en [este PR](https://github.com/uqbar-project/wollok-language/pull/116).

Si hacemos un head o last de una lista vacía debería romper.