### PR TITLE
Tick class implementation and game.createTick method to optionally instance it

### DIFF
--- a/src/wollok/game.wlk
+++ b/src/wollok/game.wlk
@@ -269,14 +269,14 @@ object game {
   */
   method doStart(isRepl) native
 
-  /*
-   * Returns an instance of Tick class, which has methods to start,
-   * stop and change the interval for a loop that executes a block of code
-   * every *interval* milliseconds.
+  /**
+   * Returns a tick object to be used for an action execution over interval time. 
+   * The interval is in milliseconds and action is a block without params.
   */
-  
-  method createTick(milliseconds, codeBlock, execInmediately) {
-    return new Tick(interval = milliseconds, action = codeBlock, inmediate = execInmediately)
+
+  method tick(interval, action, execInmediately) {
+    if (interval < 1) {game.error("Interval must be higher than zero.")}
+    return new Tick(interval = interval, action =  action, inmediate = execInmediately)
   }
 
 }
@@ -614,34 +614,57 @@ class Sound {
 }
 
 class Tick {
-  const name = self.identity()
-  const inmediate = false
-  const action
-  var interval
+  var interval /** The interval for the tick event **/
+  const name = self.identity() /** The ID associated to the tick event to be created **/
+  const action /** The action to be executed when the loop starts. **/
 
+  /** 
+   *  Indicates whether the action will be executed as soon
+   *  as the loop starts, or it will wait to the first time interval.
+  **/
+  const inmediate = false 
+ 
+
+  /**
+   * Starts looping the action passed in to the tick
+   * object when it was instantiated. 
+  **/
   method start() {
-    if (self.isRunning()) {game.error("This tick is already running.")}
+    if (self.isRunning()) {game.error("This tick is already started.")}
     if (inmediate) {action.apply()}
     game.onTick(interval, name, action)
   }
 
+  /**
+   * Stops looping the tick.
+  **/
   method stop() {
-    if (!self.isRunning()) {game.error("This tick is not running.")}
-    game.removeTickEvent(name)
-  }
-
-  method interval(milliseconds) {
     if (self.isRunning()) {
-      self.stop()
-      interval = milliseconds
-      self.start()
-    } else {
-      interval = milliseconds
+      game.removeTickEvent(name)
     }
   }
 
+  /**
+   * Stops and starts looping the tick.
+  **/ 
+  method reset() {
+    self.stop()
+    self.start()
+  }
+
+  /**
+   * Updates the tick's loop interval.
+  **/
+  method interval(milliseconds) {
+    interval = milliseconds
+    if (self.isRunning()) {self.reset()}
+  }
+
+  /**
+   * Indicates whether the tick is currently looped or not.
+  **/
   method isRunning() {
-    return io.timeHandlers().containsKey(name)
+    return io.containsTimeEvent(name)
   }
 }
 

--- a/src/wollok/game.wlk
+++ b/src/wollok/game.wlk
@@ -275,8 +275,8 @@ object game {
    * every *interval* milliseconds.
   */
   
-  method createTick(milliseconds, codeBlock) {
-    return new Tick(interval = milliseconds, action = codeBlock)
+  method createTick(milliseconds, codeBlock, execInmediately) {
+    return new Tick(interval = milliseconds, action = codeBlock, inmediate = execInmediately)
   }
 
 }

--- a/src/wollok/game.wlk
+++ b/src/wollok/game.wlk
@@ -624,14 +624,18 @@ class Tick {
   }
 
   method stop() {
-    if (!self.isRunning()) {game.error("The tick you want to remove does not exist.")}
+    if (!self.isRunning()) {game.error("This tick is not running.")}
     game.removeTickEvent(name)
   }
 
   method interval(milliseconds) {
-    self.stop()
-    interval = milliseconds
-    self.start()
+    if (self.isRunning()) {
+      self.stop()
+      interval = milliseconds
+      self.start()
+    } else {
+      interval = milliseconds
+    }
   }
 
   method isRunning() {

--- a/src/wollok/game.wlk
+++ b/src/wollok/game.wlk
@@ -1,4 +1,6 @@
 import wollok.vm.runtime
+import wollok.io.io
+
 
 /**
   * Wollok Game main object 
@@ -266,6 +268,17 @@ object game {
   * @private
   */
   method doStart(isRepl) native
+
+  /*
+   * Returns an instance of Tick class, which has methods to start,
+   * stop and change the interval for a loop that executes a block of code
+   * every *interval* miliseconds.
+  */
+  
+  method createTick(miliseconds, codeBlock) {
+    return new Tick(interval = miliseconds, action = codeBlock)
+  }
+
 }
 
 class AbstractPosition {
@@ -599,3 +612,28 @@ class Sound {
   method shouldLoop() native	
 
 }
+
+class Tick {
+  const name = self.identity()
+  const action
+  var interval
+  
+  method start() {
+    game.onTick(interval, name, action)
+  }
+
+  method stop() {
+    game.removeTickEvent(name)
+  }
+
+  method interval(miliseconds) {
+    self.stop()
+    interval = miliseconds
+    self.start()
+  }
+
+  method isRunning() {
+    return io.timeHandlers().containsKey(name)
+  }
+}
+

--- a/src/wollok/game.wlk
+++ b/src/wollok/game.wlk
@@ -615,11 +615,13 @@ class Sound {
 
 class Tick {
   const name = self.identity()
+  const inmediate = false
   const action
   var interval
-  
+
   method start() {
     if (self.isRunning()) {game.error("This tick is already running.")}
+    if (inmediate) {action.apply()}
     game.onTick(interval, name, action)
   }
 

--- a/src/wollok/game.wlk
+++ b/src/wollok/game.wlk
@@ -614,9 +614,20 @@ class Sound {
 }
 
 class Tick {
-  var interval /** The interval for the tick event **/
-  const name = self.identity() /** The ID associated to the tick event to be created **/
-  const action /** The action to be executed when the loop starts. **/
+  /** 
+  * Milliseconds to wait between each action 
+  **/
+  var interval 
+  
+  /** 
+  * The ID associated to the tick event to be created 
+  **/
+  const name = self.identity() 
+  
+  /** 
+  * Block to execute after each interval time lapse 
+  **/
+  const action 
 
   /** 
    *  Indicates whether the action will be executed as soon

--- a/src/wollok/game.wlk
+++ b/src/wollok/game.wlk
@@ -272,11 +272,11 @@ object game {
   /*
    * Returns an instance of Tick class, which has methods to start,
    * stop and change the interval for a loop that executes a block of code
-   * every *interval* miliseconds.
+   * every *interval* milliseconds.
   */
   
-  method createTick(miliseconds, codeBlock) {
-    return new Tick(interval = miliseconds, action = codeBlock)
+  method createTick(milliseconds, codeBlock) {
+    return new Tick(interval = milliseconds, action = codeBlock)
   }
 
 }
@@ -619,16 +619,18 @@ class Tick {
   var interval
   
   method start() {
+    if (self.isRunning()) {game.error("This tick is already running.")}
     game.onTick(interval, name, action)
   }
 
   method stop() {
+    if (!self.isRunning()) {game.error("The tick you want to remove does not exist.")}
     game.removeTickEvent(name)
   }
 
-  method interval(miliseconds) {
+  method interval(milliseconds) {
     self.stop()
-    interval = miliseconds
+    interval = milliseconds
     self.start()
   }
 


### PR DESCRIPTION
Fix #58
Se creó la clase Tick para crear objetos que puedan ser guardados en referencias y eventualmente activar y desactivar sus tick events asociados, así como modificar el intervalo en que se ejecutan y elegir, al crearlos, si van a comenzar la ejecución del bloque de código ni bien se loopee el tick o si se esperará a que ocurra el primer intervalo.
También se creó el método createTick en el objeto game que retorna una instancia de esta clase.

Tests en: https://github.com/uqbar-project/wollok-ts/pull/115