### PR TITLE
Agrego test palabra reservada 'wollok' en shouldNotUseReservedWords.wlk

### DIFF
--- a/test/validations/shouldNotUseReservedWords.wlk
+++ b/test/validations/shouldNotUseReservedWords.wlk
@@ -18,3 +18,6 @@ class A {
     assert.that(true)
   }
 }
+
+@Expect(code = "shouldNotUseReservedWords", value = "warning")
+const wollok =11


### PR DESCRIPTION
Agrego test para el cambio en wollok-ts: [Agrego 'wollok' a la lista de palabras reservadas #131](https://github.com/uqbar-project/wollok-ts/pull/131)