### PR TITLE
Cambios sintaxis en tests

### DIFF
--- a/test/sanity/basics/numbers/identity.wtest
+++ b/test/sanity/basics/numbers/identity.wtest
@@ -14,10 +14,10 @@ describe "number identity" {
   }
 
   test "test variables in different scopes should have the same identity" {
-    var a = 33
+    const a = 33
 
-    var o = object {
-      var b = 33
+    const o = object {
+      const b = 33
       method b() { return b }
     }
 

--- a/test/sanity/basics/ranges/ranges.wtest
+++ b/test/sanity/basics/ranges/ranges.wtest
@@ -29,12 +29,12 @@ describe "ranges" {
   }
 
   test "sum" {
-    var range = 0 .. 9 
+    const range = 0 .. 9
     assert.equals(45, range.sum())
   }
 
   test "sumClosure" {
-    var range = 0 .. 9 
+    const range = 0 .. 9
     assert.equals(90, range.sum({ n => n * 2 }))
   }
 
@@ -106,8 +106,8 @@ describe "ranges" {
     const counter = new Dictionary()
     range.forEach({n => counter.put(n,0)})
     500.times({ i =>
-      var n = range.anyOne()
-      var c = counter.get(n) + 1
+      const n = range.anyOne()
+      const c = counter.get(n) + 1
       counter.put(n,c)
     })
     range.forEach({n => assert.that(counter.get(n) > 50)})

--- a/test/sanity/basics/stringPrinter/stringPrinter.wtest
+++ b/test/sanity/basics/stringPrinter/stringPrinter.wtest
@@ -1,5 +1,5 @@
 const pepita = object {
-  var energia = 10
+  var property energia = 10
   override method toString() = "pepita"
 }
 

--- a/test/sanity/classes/initializationCross.wtest
+++ b/test/sanity/classes/initializationCross.wtest
@@ -2,8 +2,8 @@
   * Scenario: A Class with cross-referenced attributes
   */
 object abc {
-  var x = 20
-  var y = x * 2
+  const x = 20
+  const y = x * 2
 
   method getY() {
     return y

--- a/test/sanity/classes/initializationNumbers.wtest
+++ b/test/sanity/classes/initializationNumbers.wtest
@@ -2,8 +2,8 @@
   * Scenario: A Class with attributes pointing to numbers
   */
 class A {
-  var i = 10
-  var j = 0.10
+  const i = 10
+  const j = 0.10
 
   method getI() = i
   method getJ() = j

--- a/test/sanity/classes/methodsInitialization.wtest
+++ b/test/sanity/classes/methodsInitialization.wtest
@@ -2,8 +2,8 @@
   * Scenario: A Class with attributes initialized in a sequence
   */
 class Subject {
-  var x = 4
-  var y = x * 2
+  const x = 4
+  const y = x * 2
 
   method getY() = y
 }
@@ -14,7 +14,7 @@ class Subject {
 describe "classes - methods - initialization of attributes" {
 
   test "attributes initialized in a sequence" {
-    var obj = new Subject()
+    const obj = new Subject()
     assert.equals(8, obj.getY())
   }
 

--- a/test/sanity/classes/methodsReturningValue.wtest
+++ b/test/sanity/classes/methodsReturningValue.wtest
@@ -4,7 +4,7 @@
   *
   */
 class Golondrina {
-  var energia = 100
+  const energia = 100
 
   method energia() = energia
   method capacidadDeVuelo() = 10

--- a/test/sanity/collections/dictionaryTestCase.wtest
+++ b/test/sanity/collections/dictionaryTestCase.wtest
@@ -120,8 +120,8 @@ describe "dictionary test case" {
   }
 
   test "adding several swallows in a map" {
-    var pepa = new Golondrina()
-    var s = new Dictionary()
+    const pepa = new Golondrina()
+    const s = new Dictionary()
     s.put(pepa, 0)
     (1 .. 50).forEach({ i => s.put(new Golondrina(), i)}) // all objects are not == to pepa
     assert.notEquals(pepa, new Golondrina())

--- a/test/sanity/collections/set.wtest
+++ b/test/sanity/collections/set.wtest
@@ -2,11 +2,11 @@
   * Scenario: a class and a wko having common attributes
   */
 class Alumno { 
-  var nombre 
+  var property nombre
 }
 
 object manuel {
-  var nombre = "ElManu"
+  var property nombre = "ElManu"
 }
 
 /**

--- a/test/sanity/customObjects/namedObjects/multipleReferencesToSameObjectCreatesJustOneInstance.wtest
+++ b/test/sanity/customObjects/namedObjects/multipleReferencesToSameObjectCreatesJustOneInstance.wtest
@@ -2,7 +2,7 @@
   * Scenario: a wko having several references to another wko
   */
 object pepa {
-  var friend = [pepita]
+  const friend = [pepita]
   method bestFriend() {
     const bff = pepita
     return bff

--- a/test/sanity/customObjects/unnamedObjects/inheritancePropertiesConstructor.wtest
+++ b/test/sanity/customObjects/unnamedObjects/inheritancePropertiesConstructor.wtest
@@ -9,7 +9,7 @@ class Auto {
   * Tests
   */
 test "object inheriting from a class - calling a property" {
-  var age = 33
+  const age = 33
 
   const dodge = object inherits Auto(kms = 2000) {
     method age() {

--- a/test/sanity/customObjects/unnamedObjects/inheritancePropertiesNamedParameters.wtest
+++ b/test/sanity/customObjects/unnamedObjects/inheritancePropertiesNamedParameters.wtest
@@ -10,7 +10,7 @@ class Auto {
   * Tests
   */
 test "literal object inheriting from a class named parameters - calling a property" {
-  var age = 33
+  const age = 33
 
   const dodge = object inherits Auto(owner = 'dodain', kms = 2000) {
     method age() {

--- a/test/sanity/game/events.wtest
+++ b/test/sanity/game/events.wtest
@@ -20,7 +20,7 @@ object visual inherits Visual { }
 describe 'events' {
 
 
-  method initialize() {
+  override method initialize() {
     game.addVisual(visual)
   }
 

--- a/test/sanity/game/game.wtest
+++ b/test/sanity/game/game.wtest
@@ -21,7 +21,7 @@ const pepita = object { method position() = game.at(1,3) }
   */
 describe "Game" {
 
-  method initialize() {
+  override method initialize() {
     game.clear()
   }
 

--- a/test/sanity/game/ioTest.wtest
+++ b/test/sanity/game/ioTest.wtest
@@ -19,7 +19,7 @@ object closureErrorMock {
 
 describe 'flush events' {
 
-  method initialize() {
+  override method initialize() {
     game.start()
   }
 

--- a/test/sanity/game/position.wtest
+++ b/test/sanity/game/position.wtest
@@ -37,7 +37,7 @@ class Visual {
   */
 describe "position" {
 
-  method initialize() {
+  override method initialize() {
     game.clear()
   }
 

--- a/test/sanity/language/initialization/assignmentInInitialize.wtest
+++ b/test/sanity/language/initialization/assignmentInInitialize.wtest
@@ -5,7 +5,7 @@
 class D {
 	const property a
 
-	method initialize() {
+	override method initialize() {
 		a = 1
 	}
 }
@@ -13,7 +13,7 @@ class D {
 class E {
 	const property a = 2
 
-	method initialize() {
+	override method initialize() {
 		a = 1
 	}
 }

--- a/test/sanity/language/initialization/dependentInitializationOrdered.wtest
+++ b/test/sanity/language/initialization/dependentInitializationOrdered.wtest
@@ -2,7 +2,7 @@
   * Scenario: a simple initialization class with well ordered variable declarations
   */
 class A {
-  var y = 0
+  const y = 0
   var property x = y + 1
 
   method m() = y + x

--- a/test/sanity/language/initialization/initializeMethodOnClassesBasic.wtest
+++ b/test/sanity/language/initialization/initializeMethodOnClassesBasic.wtest
@@ -5,7 +5,7 @@
 class A {
 	var property a
 	
-	method initialize() {
+	override method initialize() {
 		a = 1
 	}
 }
@@ -13,7 +13,7 @@ class A {
 class B inherits A {
 	var property b
 	
-	method initialize() {
+	override method initialize() {
 		super()
 		b = 2
 	}
@@ -22,7 +22,7 @@ class B inherits A {
 class C inherits A {
 	var property b
 	
-	method initialize() {
+	override method initialize() {
 		b = 2
 	}
 }

--- a/test/sanity/language/initialization/initializeMethodOnClassesComplexCase.wtest
+++ b/test/sanity/language/initialization/initializeMethodOnClassesComplexCase.wtest
@@ -5,7 +5,7 @@
 class A {
 	var property a
 	
-	method initialize() {
+	override method initialize() {
 		a = 1
 	}
 }
@@ -13,7 +13,7 @@ class A {
 class B inherits A {
 	var property b
 	
-	method initialize() {
+	override method initialize() {
 		b = a + 1
 	}
 }
@@ -21,7 +21,7 @@ class B inherits A {
 class C inherits B {
 	var property c
 	
-	method initialize() {
+	override method initialize() {
     a = 5
 		super()
     c = b + 1

--- a/test/sanity/language/initialization/initializeOverridingVars.wtest
+++ b/test/sanity/language/initialization/initializeOverridingVars.wtest
@@ -8,7 +8,7 @@ class Persona{
   var deseos = []
 
 
-  method initialize() {
+  override method initialize() {
     // allows local variables too
     const dobleDeEdad = 2 * edad
     edad = dobleDeEdad

--- a/test/sanity/language/null.wtest
+++ b/test/sanity/language/null.wtest
@@ -41,7 +41,7 @@ describe "Null Test Case" {
   }
 
   test "== operator sent to null" {
-    var valorNulo
+    const valorNulo
     // Just to check if the null can be tested against a WKO
     // Cannot be performed directly because you should not use comparison over WKO
     const anotherAssert = assert
@@ -82,7 +82,7 @@ describe "Null Test Case" {
   }
 
   test "if in a null expression" {
-    var expresionNula
+    const expresionNula
     try {
       if (expresionNula) {
         assert.fail("Null Expression did not fail!")
@@ -102,7 +102,7 @@ describe "Null Test Case" {
   }
 
   test "check null by identity" {
-    var a = null
+    const a = null
     assert.that(a == null)
     assert.notThat(a != null)
     assert.that(a === null)

--- a/test/sanity/lazy/cyclicReferences.wtest
+++ b/test/sanity/lazy/cyclicReferences.wtest
@@ -1,9 +1,9 @@
 object juan {
-    var mascota = firulais
+    var property mascota = firulais
 }
 
 object firulais {
-    var duenio = juan
+    var property duenio = juan
 }
 
 class Entrenador{

--- a/test/sanity/mixins/hierarchy.wtest
+++ b/test/sanity/mixins/hierarchy.wtest
@@ -14,11 +14,11 @@ mixin O {
 }
 
 object a inherits M and N and B {
-    method hierarchy() = "a <: " + super()  
+    override method hierarchy() = "a <: " + super()
 }
 
 class B inherits O and C {
-    method hierarchy() =  "B <: " + super()  
+    override method hierarchy() =  "B <: " + super()
 }
 
 class C {
@@ -30,8 +30,8 @@ test "linearization from a named object with mixins and classes" {
 }
 
 mixin M0 { method hierarchy() = "M0" }
-mixin M1 inherits M0 { method hierarchy() = "M1 <: " + super() }
-mixin M2 inherits M0 { method hierarchy() = "M2 <: " + super() }
+mixin M1 inherits M0 { override method hierarchy() = "M1 <: " + super() }
+mixin M2 inherits M0 { override method hierarchy() = "M2 <: " + super() }
 
 test "linearization of common mixin ancestors should be pushed backwards to enable cake pattern default" {
   assert.equals("M0", object inherits M0 {}.hierarchy())

--- a/test/sanity/testing/describe/initializeMethod.wtest
+++ b/test/sanity/testing/describe/initializeMethod.wtest
@@ -18,7 +18,7 @@ object alpiste {
 describe "testing test initialization runs before every test" {
   const pepita = new Golondrina()
 
-  method initialize() {
+  override method initialize() {
     pepita.comer(alpiste)
     pepita.comer(alpiste)
   }
@@ -38,7 +38,7 @@ describe "testing test initialization runs before every test" {
 describe "const references cannot be initially assigned in a test initialization" {
   const uno
 
-  method initialize() {
+  override method initialize() {
     assert.throwsException { => uno = 1 }
   }
 
@@ -50,7 +50,7 @@ describe "const references cannot be initially assigned in a test initialization
 describe "const references cannot be additionally assigned in a test initialization" {
   const uno = 1
 
-  method initialize() {
+  override method initialize() {
     assert.throwsException { => uno = 1 }
   }
 
@@ -62,7 +62,7 @@ describe "const references cannot be additionally assigned in a test initializat
 describe "describe can have local variables in init method" {
   var valor = 0
 
-  method initialize() {
+  override method initialize() {
     const numero = 5
     valor = numero * 2
   }

--- a/test/sanity/testing/describe/issue1223.wtest
+++ b/test/sanity/testing/describe/issue1223.wtest
@@ -20,7 +20,7 @@ describe "issue 1223 - NPE for const defined in test initializations" {
   var unDoctorCualquiera
   var enfermo
 
-  method initialize() {
+  override method initialize() {
     enfermo = new Enfermo()
     unDoctorCualquiera = new Doctor()
     unDoctorCualquiera.calidad(2)


### PR DESCRIPTION
Realice algunos cambios menores en la sintaxis de los test para que de pasarse las validaciones se eviten algunos warnings. En este PR trate de aglutinar todos los cambios mas pequeños que no deberían generar ningún cambio en el resultado de los tests.

Luego existen una gran cantidad de test que por su propia naturaleza lanzan warnings. Por lo que siempre se lanzarían warnings.