### PR TITLE
Cambios sintaxis variables repetidas

### DIFF
--- a/test/sanity/basics/pairs/pairs.wtest
+++ b/test/sanity/basics/pairs/pairs.wtest
@@ -3,30 +3,30 @@ describe "pairs" {
   const pair = 1->2
 
   test "smoke test" {
-    const pair = new Pair(x = 1, y = 2)
-    assert.equals(pair, pair)
+    const anotherPair = new Pair(x = 1, y = 2)
+    assert.equals(anotherPair, anotherPair)
   }
 
   test "new pair" {
-    const pair = new Pair(x = 1, y = 2)
-    assert.equals(1, pair.x())
-    assert.equals(2, pair.y())
+    const anotherPair = new Pair(x = 1, y = 2)
+    assert.equals(1, anotherPair.x())
+    assert.equals(2, anotherPair.y())
   }
 
   test "arrow" {
-    const pair = 1->2
-    assert.equals(1, pair.x())
-    assert.equals(2, pair.y())
+    const anotherPair = 1->2
+    assert.equals(1, anotherPair.x())
+    assert.equals(2, anotherPair.y())
   }
 
   test "x getter" {
-    const pair = "1"->2
-    assert.equals("1", pair.x())
+    const anotherPair = "1"->2
+    assert.equals("1", anotherPair.x())
   }
 
   test "y getter" {
-    const pair = 1->"2"
-    assert.equals("2", pair.y())
+    const anotherPair = 1->"2"
+    assert.equals("2", anotherPair.y())
   }
 
   test "x constant property cannot be modified" {

--- a/test/sanity/language/null.wtest
+++ b/test/sanity/language/null.wtest
@@ -59,17 +59,19 @@ describe "Null Test Case" {
   }
   
   test "equalEqualOperatorWithANullArgument" {
+      const anotherAssert = assert
       assert.notThat(8 == null)
       assert.notThat("pepe" == null)
       assert.notThat(false == null)
       assert.notThat(2.0 == null)
       assert.notThat(1..2 == null)
       assert.notThat([1,2,3] == null)
-      assert.notThat(assert == null)
+      assert.notThat(anotherAssert == null)
       assert.notThat(new Golondrina() == null)
   }
 
   test "== operator with a null argument" {
+    const anotherAssert = assert
     assert.notThat(8 == null)
     assert.notThat("pepe" == null)
     assert.notThat(false == null)
@@ -77,7 +79,7 @@ describe "Null Test Case" {
     assert.notThat(1..2 == null)
     assert.notThat([1,2,3] == null)
     assert.notThat(#{1,2,3} == null)
-    assert.notThat(assert == null)
+    assert.notThat(anotherAssert == null)
     assert.notThat(new Golondrina() == null)
   }
 

--- a/test/sanity/language/null.wtest
+++ b/test/sanity/language/null.wtest
@@ -60,9 +60,10 @@ describe "Null Test Case" {
   
   test "equalEqualOperatorWithANullArgument" {
       const anotherAssert = assert
+      const aFalse = false
       assert.notThat(8 == null)
       assert.notThat("pepe" == null)
-      assert.notThat(false == null)
+      assert.notThat(aFalse == null)
       assert.notThat(2.0 == null)
       assert.notThat(1..2 == null)
       assert.notThat([1,2,3] == null)
@@ -72,9 +73,10 @@ describe "Null Test Case" {
 
   test "== operator with a null argument" {
     const anotherAssert = assert
+    const aFalse = false
     assert.notThat(8 == null)
     assert.notThat("pepe" == null)
-    assert.notThat(false == null)
+    assert.notThat(aFalse == null)
     assert.notThat(2.0 == null)
     assert.notThat(1..2 == null)
     assert.notThat([1,2,3] == null)

--- a/test/sanity/lazy/cyclicReferences.wtest
+++ b/test/sanity/lazy/cyclicReferences.wtest
@@ -24,7 +24,8 @@ object elEntrenador inherits Entrenador(equipo = elEquipo) { }
 
 
 test "cyclic references for wko" {
-  assert.that(juan !== null)
+  const oJuan = juan
+  assert.that(oJuan !== null)
 }
 
 test "cyclic references for named objects with inherits named params" {


### PR DESCRIPTION
En este pr tengo principalmente cambios por el warn de: shouldNotDuplicateLocalVariables
Al cambiar el nombre de las variables locales no estoy seguro de si no estoy afectando el objetivo del test. ¿Hay alguna razón para que el nombre se repitiera?Por ej, ¿Se busca ver cual es la referencia a un par que se toma o solo se esta testeando los pares? Entiendo que no es el caso y que por lo tanto se pueden renombrar esas variables.
Tambien hay uno por: shouldNotCompareEqualityOfSingleton . Este me deja ciertas dudas. La manera en que lo solucioné fue asignandolo a una constante. Entiendo que eso no debería dañar la naturaleza del test visto que el ciclo de referencias infinitas debería seguir.