### PR TITLE
Test circular imports

### DIFF
--- a/test/examples/trenes/depositos.wlk
+++ b/test/examples/trenes/depositos.wlk
@@ -1,0 +1,10 @@
+import trenes.*
+
+class Deposito {
+  const formaciones = []
+
+  method agregarFormacion(unTren) { formaciones.add(unTren) }
+  method vagonesMasPesados() { return formaciones.map { tren => tren.vagonMasPesado()} }
+}
+
+const tren1 = new Tren()

--- a/test/examples/trenes/trenes.wlk
+++ b/test/examples/trenes/trenes.wlk
@@ -1,9 +1,4 @@
-class Deposito {
-  const formaciones = []
-
-  method agregarFormacion(unTren) { formaciones.add(unTren) }
-  method vagonesMasPesados() { return formaciones.map { tren => tren.vagonMasPesado()} }
-}
+import depositos.*
 
 class Tren {
   const vagones = []
@@ -60,3 +55,5 @@ class VagonCarga inherits Vagon {
   override method cantidadPasajeros() = 0
   override method pesoMaximo() = cargaMaxima + 160
 }
+
+const deposito1 = new Deposito()

--- a/test/examples/trenes/trenesTest.wtest
+++ b/test/examples/trenes/trenesTest.wtest
@@ -1,8 +1,9 @@
-import solucion.*
+import trenes.*
+import depositos.*
 
 describe "trenes example" {
 
-  const tren = new Tren()
+  const tren = tren1
 
   method initialize() {
     tren.agregarVagon(new VagonPasajeros(ancho = 2, largo = 10))
@@ -91,7 +92,7 @@ describe "deposito" {
   const trenNoSeMueve = new Tren()
   const vagonMasPesadoDeTren = new VagonPasajeros(ancho = 3, largo = 10)
   const vagonMasPesadoDeTrenNoSeMueve = new VagonPasajeros(ancho = 3, largo = 12)
-  const deposito = new Deposito()
+  const deposito = deposito1
 
   method initialize() {
     tren.agregarVagon(new VagonPasajeros(ancho = 2, largo = 10))

--- a/test/validations/shouldHaveCircularImports.wlk
+++ b/test/validations/shouldHaveCircularImports.wlk
@@ -1,0 +1,5 @@
+import shouldHaveCircularImports2.*
+
+object o {
+    const property x = 1
+}

--- a/test/validations/shouldHaveCircularImports2.wlk
+++ b/test/validations/shouldHaveCircularImports2.wlk
@@ -1,0 +1,1 @@
+import shouldHaveCircularImports.*


### PR DESCRIPTION
Había un problema* cuando había imports circulares. Agregué algunos tests para eso.

(*) El problema era que armaba un grafo de scopes con ciclos que luego no se podían JSONear para la cache