### PR TITLE
Fix Wollok-TS issue with new for Set & List

### DIFF
--- a/test/sanity/collections/list.wtest
+++ b/test/sanity/collections/list.wtest
@@ -10,6 +10,15 @@ object o2 {}
 
 describe "List tests" {
 
+  test "list initialization vs. literals" {
+    assert.equals([], new List())
+    const list = new List()
+    list.add(1)
+    assert.equals([1], list)
+    list.add(2)
+    assert.equals([1, 2], list)
+  }
+
   test "subList" {
     assert.equals([22,2], numbers.subList(0,1))
     assert.equals([22,2,10], numbers.subList(0,2))

--- a/test/sanity/collections/set.wtest
+++ b/test/sanity/collections/set.wtest
@@ -19,6 +19,15 @@ describe "set tests" {
   const aSet = #{1, 2, 3}
   const anotherSet = #{3, 4, 5}
 
+  test "set initialization vs. literals" {
+    assert.equals(#{}, new Set())
+    const set = new Set()
+    set.add(1)
+    assert.equals(#{1}, set)
+    set.add(2)
+    assert.equals(#{2, 1}, set)
+  }
+
   test "union with empty set" {
     assert.equals(aSet, aSet.union(#{}))
     assert.equals(aSet, #{}.union(aSet))


### PR DESCRIPTION
Este cuatri un grupo de chicos usó `new List()` en lugar del literal `[]`y probándolo en wollok-ts se me rompía todo. Agrego tests para probar que funcione.