### PR TITLE
Agregado de expectedOn para los tests

### DIFF
--- a/test/validations/codeShouldBeReachable.wlk
+++ b/test/validations/codeShouldBeReachable.wlk
@@ -3,13 +3,13 @@ object pepita {
 
 object p {
   method testingIfWithUnreachableCode() {
-    @Expect(code="codeShouldBeReachable", level="error")
+    @Expect(code="codeShouldBeReachable", level="error", expectedOn="throw new Exception(message = \"else\")\n          \n    ")
     if (true)
       throw new Exception(message = "asd")
     else 
       throw new Exception(message = "else")
           
-    @Expect(code="codeShouldBeReachable", level="error")
+    @Expect(code="codeShouldBeReachable", level="error", expectedOn="throw new Exception(message = \"asd\")\n    ")
     if (false)
       throw new Exception(message = "asd")
     else 
@@ -23,15 +23,15 @@ object p {
     //
     // AND
     //
-    cond = @Expect(code="codeShouldBeReachable", level="error") (false and algo)
+    cond = @Expect(code="codeShouldBeReachable", level="error", expectedOn="algo") (false and algo)
 
-    cond = @Expect(code="codeShouldBeReachable", level="error") (false && algo)
+    cond = @Expect(code="codeShouldBeReachable", level="error", expectedOn="algo") (false && algo)
 
     //
     // OR
     //
-    cond = @Expect(code="codeShouldBeReachable", level="error") (true or algo)
+    cond = @Expect(code="codeShouldBeReachable", level="error", expectedOn="algo") (true or algo)
 
-    cond = @Expect(code="codeShouldBeReachable", level="error") (true || algo)
+    cond = @Expect(code="codeShouldBeReachable", level="error", expectedOn="algo") (true || algo)
   }
 }

--- a/test/validations/codeShouldBeReachable.wlk
+++ b/test/validations/codeShouldBeReachable.wlk
@@ -3,13 +3,13 @@ object pepita {
 
 object p {
   method testingIfWithUnreachableCode() {
-    @Expect(code="codeShouldBeReachable", level="error", expectedOn="throw new Exception(message = \"else\")\n          \n    ")
+    @Expect(code="codeShouldBeReachable", level="error", expectedOn="throw new Exception(message = \"else\")")
     if (true)
       throw new Exception(message = "asd")
     else 
       throw new Exception(message = "else")
           
-    @Expect(code="codeShouldBeReachable", level="error", expectedOn="throw new Exception(message = \"asd\")\n    ")
+    @Expect(code="codeShouldBeReachable", level="error", expectedOn="throw new Exception(message = \"asd\")")
     if (false)
       throw new Exception(message = "asd")
     else 

--- a/test/validations/getterMethodShouldReturnAValue.wlk
+++ b/test/validations/getterMethodShouldReturnAValue.wlk
@@ -4,7 +4,7 @@ class A {
 	method getFirstName() { return "John" }
 	method getLastName() = "Doe"
 	
-	@Expect(code = "getterMethodShouldReturnAValue", value = "warning")
+	@Expect(code = "getterMethodShouldReturnAValue", level = "warning", expectedOn="console.println(\"blah\") ")
 	method ageFromAClass() { console.println("blah") }
 
 	// this are not getters	
@@ -30,7 +30,7 @@ object anObject {
 	method getFirstName() { return "John" }
 	method getLastName() = "Doe"
 	
-	@Expect(code = "getterMethodShouldReturnAValue", value = "warning")
+	@Expect(code = "getterMethodShouldReturnAValue", level = "warning", expectedOn="console.println(\"blah\") ")
 	method age() { console.println("blah") }
 
 	// this are not getters	

--- a/test/validations/inlineSingletonShouldBeAnonymous.wlk
+++ b/test/validations/inlineSingletonShouldBeAnonymous.wlk
@@ -5,6 +5,6 @@ object namedObject {
 
   method m() {
     // Inline objects must be unnamed
-    return @Expect(code="inlineSingletonShouldBeAnonymous", level="error") object otherNamedObject { }
+    return @Expect(code="inlineSingletonShouldBeAnonymous", level="error", expectedOn="otherNamedObject") object otherNamedObject { }
   }
 }

--- a/test/validations/methodShouldExist.wlk
+++ b/test/validations/methodShouldExist.wlk
@@ -3,7 +3,7 @@ class Persona {
     return "hardcodeado"
   }
   method blah() {
-    @Expect(code="methodShouldExist", level="error")
+    @Expect(code="methodShouldExist", level="error", expectedOn="self.bleh()")
     (self.bleh())
   }
   method primitiveMethod()
@@ -18,7 +18,7 @@ class Profesor inherits Persona {
   method subBlah() {
     self.getNombre()
     self.blah()
-    @Expect(code="methodShouldExist", level="error")
+    @Expect(code="methodShouldExist", level="error", expectedOn="self.bleh()")
     (self.bleh())
   }
   override method primitiveMethod() {}
@@ -30,7 +30,7 @@ object o {
   }
   method bar() {
     self.foo()
-    @Expect(code="methodShouldExist", level="error")
+    @Expect(code="methodShouldExist", level="error", expectedOn="self.foobar()")
     (self.foobar())
   }
 }
@@ -42,7 +42,7 @@ mixin M {
     self.implemented()
   }
   method implemented() {
-    @Expect(code="methodShouldExist", level="error")
+    @Expect(code="methodShouldExist", level="error", expectedOn="self.notImplemented()")
     (self.notImplemented())
   }
   method primitive()
@@ -53,32 +53,32 @@ class Personaje {
     pepita.foo()
     pepita.bar()
     
-    @Expect(code="methodShouldExist", level="error")
+    @Expect(code="methodShouldExist", level="error", expectedOn="pepita.fooBar()")
     (pepita.fooBar())
     
-    @Expect(code="methodShouldExist", level="error")
+    @Expect(code="methodShouldExist", level="error", expectedOn="pepita.fooBar(2, \"hola\")")
     (pepita.fooBar(2, "hola"))
     
-    @Expect(code="methodShouldExist", level="error")
+    @Expect(code="methodShouldExist", level="error", expectedOn="pepita.fooWithParam()")
     (pepita.fooWithParam())
 
-    @Expect(code="methodShouldExist", level="error")
+    @Expect(code="methodShouldExist", level="error", expectedOn="pepita.fooWithParam(new Date(), 2, 4)")
     (pepita.fooWithParam(new Date(), 2, 4))
 
-    @Expect(code="methodShouldExist", level="error")
+    @Expect(code="methodShouldExist", level="error", expectedOn="pepita.foO()")
     (pepita.foO())
     
-    @Expect(code="methodShouldExist", level="error")
+    @Expect(code="methodShouldExist", level="error", expectedOn="pepita.severalDef()")
     (pepita.severalDef())
     
-    @Expect(code="methodShouldExist", level="error")
+    @Expect(code="methodShouldExist", level="error", expectedOn="pepita.severalDef(1, 2, 3, 4)")
     (pepita.severalDef(1, 2, 3, 4))
   }
 }
 
 class B {
   const i = pepita.foo()
-  const x = @Expect(code="methodShouldExist", level="error") (pepita.zoo())
+  const x = @Expect(code="methodShouldExist", level="error", expectedOn="pepita.zoo()") (pepita.zoo())
   
   method a() = i + x
 }

--- a/test/validations/missingReference.wlk
+++ b/test/validations/missingReference.wlk
@@ -5,18 +5,18 @@ object pepita {
   method energia() = (@Expect(code="missingReference", level="error", expectedOn="energia") energia)
   
   method comer(p) {
-    @Expect(code="missingReference", level="error", path="variable")
+    @Expect(code="missingReference", level="error", path="variable", expectedOn="energia")
     energia = 100
   }
 
-  method estaCansada() = (@Expect(code="missingReference", level="error") energia < 10)
+  method estaCansada() = (@Expect(code="missingReference", level="error", expectedOn="energia") energia < 10)
 
   method methodName() {
-    self.comer(@Expect(code="missingReference", level="error") energia)
+    self.comer(@Expect(code="missingReference", level="error", expectedOn="energia") energia)
   } 
 }
 
-class C inherits @Expect(code="missingReference", level="error", path="reference") InexistentClass {
+class C inherits @Expect(code="missingReference", level="error", path="reference", expectedOn="InexistentClass") InexistentClass {
   method catchingNonExistingException() {
     try {
       assert.that(true)
@@ -29,6 +29,6 @@ class C inherits @Expect(code="missingReference", level="error", path="reference
   }
 }
 
-mixin M inherits @Expect(code="missingReference", level="error", path="reference") InexistentMixin { }
+mixin M inherits @Expect(code="missingReference", level="error", path="reference", expectedOn="InexistentMixin") InexistentMixin { }
 
 const a = new @Expect(code = "missingReference", level="error", expectedOn="InexistClass") InexistClass(edad = 5)

--- a/test/validations/missingReference.wlk
+++ b/test/validations/missingReference.wlk
@@ -1,8 +1,8 @@
-import @Expect(code="missingReference", level="error") inexistentFile.*
+import @Expect(code="missingReference", level="error", expectedOn="inexistentFile") inexistentFile.*
 
 object pepita {
   
-  method energia() = (@Expect(code="missingReference", level="error") energia)
+  method energia() = (@Expect(code="missingReference", level="error", expectedOn="energia") energia)
   
   method comer(p) {
     @Expect(code="missingReference", level="error", path="variable")
@@ -21,7 +21,7 @@ class C inherits @Expect(code="missingReference", level="error", path="reference
     try {
       assert.that(true)
     } 
-    catch e: @Expect(code = "missingReference", level="error") InexistentException
+    catch e: @Expect(code = "missingReference", level="error", expectedOn="InexistentException") InexistentException
       assert.fail("InexistentException does not exist")
     @Expect(code = "catchShouldBeReachable", level="error")
     catch e: Exception
@@ -31,4 +31,4 @@ class C inherits @Expect(code="missingReference", level="error", path="reference
 
 mixin M inherits @Expect(code="missingReference", level="error", path="reference") InexistentMixin { }
 
-const a = new @Expect(code = "missingReference", level="error") InexistClass(edad = 5)
+const a = new @Expect(code = "missingReference", level="error", expectedOn="InexistClass") InexistClass(edad = 5)

--- a/test/validations/nameShouldBeginWithLowercase.wlk
+++ b/test/validations/nameShouldBeginWithLowercase.wlk
@@ -1,20 +1,20 @@
 
-@Expect(code="nameShouldBeginWithLowercase", level="warning")
+@Expect(code="nameShouldBeginWithLowercase", level="warning", expectedOn="SomeObject")
 object SomeObject {}
 
 object pepita {
   var energy = 100
-  @Expect(code="nameShouldBeginWithLowercase", level="warning")
+  @Expect(code="nameShouldBeginWithLowercase", level="warning", expectedOn="FlyCount")
   var FlyCount = 1
 
-  method fly(@Expect(code="nameShouldBeginWithLowercase", level="warning") Minutes) {
+  method fly(@Expect(code="nameShouldBeginWithLowercase", level="warning", expectedOn="Minutes") Minutes) {
     FlyCount = FlyCount + 1
     energy = energy - (4 * Minutes)
   }
 
   method eat(grams) {
     const doubleGrams = grams * 2
-    @Expect(code="nameShouldBeginWithLowercase", level="warning")
+    @Expect(code="nameShouldBeginWithLowercase", level="warning", expectedOn="Total")
     var Total = doubleGrams + 100
     Total = Total / energy
     energy = energy + Total

--- a/test/validations/nameShouldBeginWithUppercase.wlk
+++ b/test/validations/nameShouldBeginWithUppercase.wlk
@@ -1,10 +1,10 @@
 
-@Expect(code="nameShouldBeginWithUppercase", level="warning")
+@Expect(code="nameShouldBeginWithUppercase", level="warning", expectedOn="bird")
 class bird {}
 
 class SomeClass {}
 
 class MockingBird inherits bird {}
 
-@Expect(code="nameShouldBeginWithUppercase", level="warning")
+@Expect(code="nameShouldBeginWithUppercase", level="warning", expectedOn="flies")
 mixin flies {}

--- a/test/validations/nameShouldNotBeKeyword.wpgm
+++ b/test/validations/nameShouldNotBeKeyword.wpgm
@@ -1,24 +1,24 @@
-@Expect(code="nameShouldNotBeKeyword", level="error")
+@Expect(code="nameShouldNotBeKeyword", level="error", expectedOn="object")
 object object {
-  method invalidParam(@Expect(code="nameShouldNotBeKeyword", level="error") test) = true
+  method invalidParam(@Expect(code="nameShouldNotBeKeyword", level="error", expectedOn="test") test) = true
 }
 
 class SomeClass {
-  @Expect(code="nameShouldNotBeKeyword", level="error")
+  @Expect(code="nameShouldNotBeKeyword", level="error", expectedOn="var")
   var var = 11
 
-  @Expect(code="nameShouldNotBeKeyword", level="error")
+  @Expect(code="nameShouldNotBeKeyword", level="error", expectedOn="var")
   method var() = var
   
-  @Expect(code="nameShouldNotBeKeyword", level="error")
+  @Expect(code="nameShouldNotBeKeyword", level="error", expectedOn="method")
   method method() {
-    @Expect(code="nameShouldNotBeKeyword", level="error")
+    @Expect(code="nameShouldNotBeKeyword", level="error", expectedOn="const")
     const const = 1
   }
 
 }
 
-@Expect(code="nameShouldNotBeKeyword", level="error")
+@Expect(code="nameShouldNotBeKeyword", level="error", expectedOn="program")
 program program {
   console.println(new SomeClass())
 }

--- a/test/validations/namedArgumentShouldExist.wlk
+++ b/test/validations/namedArgumentShouldExist.wlk
@@ -6,7 +6,7 @@
 class SomeClass {
   var property someAttribute = "hello"
   const property constProperty = 1
-  method createDateWithBadParam() = new Date(@Expect(code="namedArgumentShouldExist", level="error") hour = 10, month = 2, year = 2020)
+  method createDateWithBadParam() = new Date(@Expect(code="namedArgumentShouldExist", level="error", expectedOn="hour") hour = 10, month = 2, year = 2020)
 }
 
 class SubclassOfSomeClass inherits SomeClass {
@@ -24,13 +24,13 @@ class StackableClass inherits SomeMixin and SomeClass {
 class AnotherClass {
   var someClass
   method updateSomeClassUsingUnexistentAttribute() {
-    someClass = new SomeClass(@Expect(code="namedArgumentShouldExist", level="error") badAttribute = "bye")
+    someClass = new SomeClass(@Expect(code="namedArgumentShouldExist", level="error", expectedOn="badAttribute") badAttribute = "bye")
   }
   method updateSomeClassCorrectly() {
     someClass = new SomeClass(someAttribute = "bye")
   }
   method updateSomeSubclassUsingUnexistentAttribute() {
-    someClass = new SubclassOfSomeClass(@Expect(code="namedArgumentShouldExist", level="error") badAttribute = "bye")
+    someClass = new SubclassOfSomeClass(@Expect(code="namedArgumentShouldExist", level="error", expectedOn="badAttribute") badAttribute = "bye")
   }
   method updateSomeSubclassCorrectly() {
     someClass = new SubclassOfSomeClass(someAttribute = "bye", constProperty = 2)
@@ -38,17 +38,17 @@ class AnotherClass {
   method throwingExceptionOk() {
     throw new MessageNotUnderstoodException(message = "Some message")
   }
-  method usingMixinUsingUnexistenteAttribute() = new StackableClass(stackableAttribute = 1, @Expect(code="namedArgumentShouldExist", level="error") mixinAttributeNotFound = "bye", someAttribute = "ok")
+  method usingMixinUsingUnexistenteAttribute() = new StackableClass(stackableAttribute = 1, @Expect(code="namedArgumentShouldExist", level="error", expectedOn="mixinAttributeNotFound") mixinAttributeNotFound = "bye", someAttribute = "ok")
   method usingMixedClassOk() = new StackableClass(stackableAttribute = 1, mixinAttribute = "bye", someAttribute = "ok")
 }
 
 object someObjectOk inherits SomeClass(someAttribute = "good!") {}
 
-object someObjectUnexistentAttribute inherits SomeClass(@Expect(code="namedArgumentShouldExist", level="error") badAttribute = 0) {}
+object someObjectUnexistentAttribute inherits SomeClass(@Expect(code="namedArgumentShouldExist", level="error", expectedOn="badAttribute") badAttribute = 0) {}
 
 const literalOk = object inherits SomeClass(someAttribute = "good!") {}
 
-const literalUnexistentAttribute = object inherits SomeClass(@Expect(code="namedArgumentShouldExist", level="error") badAttribute = 0) {}
+const literalUnexistentAttribute = object inherits SomeClass(@Expect(code="namedArgumentShouldExist", level="error", expectedOn="badAttribute") badAttribute = 0) {}
 
 /* ================================================================================
  * - using a combined hierarchy of classes and mixins
@@ -71,9 +71,9 @@ mixin M {
   method w() = w
 }
 
-class C1 inherits M and B(@Expect(code="namedArgumentShouldExist", level="error") q = 3) { } // missing 'q'
-class C2 inherits M and B(@Expect(code="namedArgumentShouldExist", level="error") w = 3) { } // missing 'w'
-class C3 inherits M(@Expect(code="namedArgumentShouldExist", level="error") z = 3) and B { } // missing 'z'
+class C1 inherits M and B(@Expect(code="namedArgumentShouldExist", level="error", expectedOn="q") q = 3) { } // missing 'q'
+class C2 inherits M and B(@Expect(code="namedArgumentShouldExist", level="error", expectedOn="w") w = 3) { } // missing 'w'
+class C3 inherits M(@Expect(code="namedArgumentShouldExist", level="error", expectedOn="z") z = 3) and B { } // missing 'z'
 class C4 inherits M and B(x = 0) { }        // OK! x = 0
 class C5 inherits M and B(y = 0) { }        // OK! x = 1, y = 0
 class C6 inherits M and B(z = 0) { }        // OK! x = 1, z = 0

--- a/test/validations/namedArgumentShouldNotAppearMoreThanOnce.wlk
+++ b/test/validations/namedArgumentShouldNotAppearMoreThanOnce.wlk
@@ -1,7 +1,7 @@
 class SomeClass {
   var property someAttribute = "hello"
   const property constProperty = 1
-  method createDateWithBadParam() = new Date(@Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning") day = 10, @Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning") day = 11, month = 2, year = 2020)
+  method createDateWithBadParam() = new Date(@Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning", expectedOn="day") day = 10, @Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning", expectedOn="day") day = 11, month = 2, year = 2020)
 }
 
 class SubclassOfSomeClass inherits SomeClass {
@@ -18,13 +18,13 @@ class StackableClass inherits SomeMixin and SomeClass {
 class AnotherClass {
   var someClass
   method updateSomeClassUsingRepeatedNamedParameter() {
-    someClass = new SomeClass(@Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning") someAttribute = "bye", @Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning") someAttribute = "good bye")
+    someClass = new SomeClass(@Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning", expectedOn="someAttribute") someAttribute = "bye", @Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning", expectedOn="someAttribute") someAttribute = "good bye")
   }
   method updateSomeSubclassUsingRepeatedNamedParameter() {
-    someClass = new SubclassOfSomeClass(@Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning") constProperty = "bye", @Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning") constProperty = "good bye")
+    someClass = new SubclassOfSomeClass(@Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning", expectedOn="constProperty") constProperty = "bye", @Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning", expectedOn="constProperty") constProperty = "good bye")
   }
   method throwingExceptionRepeatedNamedParameters() {
-    throw new MessageNotUnderstoodException(@Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning") message = "Some message", @Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning") message = "Some different message")
+    throw new MessageNotUnderstoodException(@Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning", expectedOn="message") message = "Some message", @Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning", expectedOn="message") message = "Some different message")
   }
-  method usingMixinUsingRepeatedNamedParameters() = new StackableClass(@Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning") stackableAttribute = 1, @Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning") stackableAttribute = 0, someAttribute = "ok")
+  method usingMixinUsingRepeatedNamedParameters() = new StackableClass(@Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning", expectedOn="stackableAttribute") stackableAttribute = 1, @Expect(code="namedArgumentShouldNotAppearMoreThanOnce", level="warning", expectedOn="stackableAttribute") stackableAttribute = 0, someAttribute = "ok")
 }

--- a/test/validations/overridingMethodShouldHaveABody.wlk
+++ b/test/validations/overridingMethodShouldHaveABody.wlk
@@ -5,7 +5,7 @@ class Foo {
 }
 
 class Baz inherits Foo {
-  @Expect(code="overridingMethodShouldHaveABody", level="error")
+  @Expect(code="overridingMethodShouldHaveABody", level="error", expectedOn="foo")
   override method foo()
     
   // this one is ok in terms of not having a body

--- a/test/validations/parameterShouldNotDuplicateExistingVariable.wlk
+++ b/test/validations/parameterShouldNotDuplicateExistingVariable.wlk
@@ -2,15 +2,15 @@ class Person {
   var property toBeHidden = 23
 
   method repeatedParameters(
-    @Expect(code="parameterShouldNotDuplicateExistingVariable", level="error")
+    @Expect(code="parameterShouldNotDuplicateExistingVariable", level="error", expectedOn="p1")
     p1,
-    @Expect(code="parameterShouldNotDuplicateExistingVariable", level="error")
+    @Expect(code="parameterShouldNotDuplicateExistingVariable", level="error", expectedOn="p1")
     p1
   ) {}  
   
   
   method hidingFieldWithParameter(
-    @Expect(code="parameterShouldNotDuplicateExistingVariable", level="error")
+    @Expect(code="parameterShouldNotDuplicateExistingVariable", level="error", expectedOn="toBeHidden")
     toBeHidden
   ) {}
   

--- a/test/validations/possiblyReturningBlock.wlk
+++ b/test/validations/possiblyReturningBlock.wlk
@@ -6,39 +6,33 @@ class SomeClass {
     b = 5
   }
 
-  @Expect(code="possiblyReturningBlock", level="warning", expectedOn="{
+  @Expect(code="possiblyReturningBlock", level="warning", expectedOn="method fakeReturn() = {
     return 2
-  }
-
-  ")
+  }")
   method fakeReturn() = {
     return 2
   }
 
-  @Expect(code="possiblyReturningBlock", level="warning", expectedOn="{ return }
-
-  ")
+  @Expect(code="possiblyReturningBlock", level="warning", expectedOn="method fakeReturnUsingVoidClosure() = { return }")
   method fakeReturnUsingVoidClosure() = { return }
 
-  @Expect(code="possiblyReturningBlock", level="warning", expectedOn="{
+  @Expect(code="possiblyReturningBlock", level="warning", expectedOn="method fakeReturnUsingVariables() = {
     return a + b
-  }
-
-  ")
+  }")
   method fakeReturnUsingVariables() = {
     return a + b
   }
 
-  @Expect(code="possiblyReturningBlock", level="warning", expectedOn="{
+  @Expect(code="possiblyReturningBlock", level="warning", expectedOn="method fakeReturnUsingAssignment() = {
     a = 3
   }
 
-  ")
+  // It is ok if method is not defined as synthetic, you can return a closure with no params")
   method fakeReturnUsingAssignment() = {
     a = 3
   }
 
-  // It's ok if method is not defined as synthetic, you can return a closure with no params
+  // It is ok if method is not defined as synthetic, you can return a closure with no params
   method okReturn() {
     return {
       return 2

--- a/test/validations/possiblyReturningBlock.wlk
+++ b/test/validations/possiblyReturningBlock.wlk
@@ -6,20 +6,34 @@ class SomeClass {
     b = 5
   }
 
-  @Expect(code="possiblyReturningBlock", level="warning")
+  @Expect(code="possiblyReturningBlock", level="warning", expectedOn="{
+    return 2
+  }
+
+  ")
   method fakeReturn() = {
     return 2
   }
 
-  @Expect(code="possiblyReturningBlock", level="warning")
+  @Expect(code="possiblyReturningBlock", level="warning", expectedOn="{ return }
+
+  ")
   method fakeReturnUsingVoidClosure() = { return }
 
-  @Expect(code="possiblyReturningBlock", level="warning")
+  @Expect(code="possiblyReturningBlock", level="warning", expectedOn="{
+    return a + b
+  }
+
+  ")
   method fakeReturnUsingVariables() = {
     return a + b
   }
 
-  @Expect(code="possiblyReturningBlock", level="warning")
+  @Expect(code="possiblyReturningBlock", level="warning", expectedOn="{
+    a = 3
+  }
+
+  ")
   method fakeReturnUsingAssignment() = {
     a = 3
   }

--- a/test/validations/shouldDefineConstInsteadOfVar.wlk
+++ b/test/validations/shouldDefineConstInsteadOfVar.wlk
@@ -1,6 +1,6 @@
 object variableShouldBeConst {
 	var variable = 123
-	@Expect(code = "shouldDefineConstInsteadOfVar", level="warning")
+	@Expect(code = "shouldDefineConstInsteadOfVar", level="warning", expectedOn="constantValue")
 	var constantValue = 321
 	
 	method doSomething() {
@@ -13,7 +13,7 @@ object localVariableInMethodShouldBeConst {
 	var variable = 123
 	
 	method doSomething() {
-		@Expect(code = "shouldDefineConstInsteadOfVar", level="warning")
+		@Expect(code = "shouldDefineConstInsteadOfVar", level="warning", expectedOn="constantValue")
 		var constantValue = 321
 		variable = 666
 		return variable + constantValue
@@ -32,7 +32,7 @@ object variableWithSingleAssignment {
 
 class VariableShouldBeConst {
 	var variable = 123
-	@Expect(code = "shouldDefineConstInsteadOfVar", level="warning")
+	@Expect(code = "shouldDefineConstInsteadOfVar", level="warning", expectedOn="constantValue")
 	var constantValue = 321
 	
 	method doSomething() {
@@ -45,7 +45,7 @@ class LocalVariableInMethodShouldBeConst {
 	var variable = 123
 	
 	method doSomething() {
-		@Expect(code = "shouldDefineConstInsteadOfVar", level="warning")
+		@Expect(code = "shouldDefineConstInsteadOfVar", level="warning", expectedOn="constantValue")
 		var constantValue = 321
 		variable = 666
 		return variable + constantValue
@@ -64,7 +64,7 @@ class VariableWithSingleAssignmentAtInitializationNotRaisesWarningIfProperty {
 
 mixin VariableShouldBeConstMixin {
 	var variable = 123
-	@Expect(code = "shouldDefineConstInsteadOfVar", level="warning")
+	@Expect(code = "shouldDefineConstInsteadOfVar", level="warning", expectedOn="constantValue")
 	var constantValue = 321
 	
 	method doSomething() {
@@ -77,7 +77,7 @@ mixin LocalVariableInMethodShouldBeConstMixin {
 	var variable = 123
 	
 	method doSomething() {
-		@Expect(code = "shouldDefineConstInsteadOfVar", level="warning")
+		@Expect(code = "shouldDefineConstInsteadOfVar", level="warning", expectedOn="constantValue")
 		var constantValue = 321
 		variable = 666
 		return variable + constantValue
@@ -150,7 +150,7 @@ object variableDefinedInLambdaWithReassignmentNotRaisesWarning {
 	
 	method fly() {
 		[ 1, 2 ].map { number =>
-			@Expect(code = "shouldDefineConstInsteadOfVar", level="warning")
+			@Expect(code = "shouldDefineConstInsteadOfVar", level="warning", expectedOn="anotherNumber")
 			var anotherNumber = number + 1
 			return anotherNumber + 2
 		}

--- a/test/validations/shouldHaveAssertInTest.wtest
+++ b/test/validations/shouldHaveAssertInTest.wtest
@@ -77,16 +77,14 @@ describe "asserts unificados" {
   }
 
   @Expect(code="shouldHaveAssertInTest", level="warning", expectedOn="const a = 1
-    if (a > 0) assert.equals(a, 1)
-  ")
+    if (a > 0) assert.equals(a, 1)")
   test "testNotOkIfWithAssertOnlyInThen" {
     const a = 1
     if (a > 0) assert.equals(a, 1)
   }
 
   @Expect(code="shouldHaveAssertInTest", level="warning", expectedOn="var a = 1
-    if (a > 0) { a = a + 1 } else assert.equals(a, 1)
-  ")
+    if (a > 0) { a = a + 1 } else assert.equals(a, 1)")
   test "testNotOkIfWithAssertOnlyInElse" {
     var a = 1
     if (a > 0) { a = a + 1 } else assert.equals(a, 1)
@@ -96,8 +94,7 @@ describe "asserts unificados" {
       1 / 0
     } catch e : Exception {
       1 + 1
-    }
-  ")
+    }")
   test "testTryCatchWithoutAssert" {
     try {
       1 / 0
@@ -131,8 +128,7 @@ describe "asserts unificados" {
       a = 2
     } then always {
       a = 3
-    }
-  ")
+    }")
   test "testTryCatchThenAlwaysWithoutAssert" {
     var a = 0
     try {
@@ -150,16 +146,14 @@ describe "asserts unificados" {
   }
 
   @Expect(code="shouldHaveAssertInTest", level="warning", expectedOn="const a = 1
-    if (a > 0) assert.equals(a, 1)
-  ")
+    if (a > 0) assert.equals(a, 1)")
   test "testElseWithoutAssert" {
     const a = 1
     if (a > 0) assert.equals(a, 1)
   }
 
   @Expect(code="shouldHaveAssertInTest", level="warning", expectedOn="var a = 1
-    if (a > 0) a = 2 else assert.equals(a, 1)
-  ")
+    if (a > 0) a = 2 else assert.equals(a, 1)")
   test "testIfWithoutAssert" {
     var a = 1
     if (a > 0) a = 2 else assert.equals(a, 1)

--- a/test/validations/shouldHaveAssertInTest.wtest
+++ b/test/validations/shouldHaveAssertInTest.wtest
@@ -33,7 +33,7 @@ describe "asserts unificados" {
     assert.equals(100, energiaInicial)
   }
 
-  @Expect(code="shouldHaveAssertInTest", level="warning")
+  @Expect(code="shouldHaveAssertInTest", level="warning", expectedOn="1 + 1")
   test "testWithBinaryOperation" {
     1 + 1
   }
@@ -42,7 +42,7 @@ describe "asserts unificados" {
     assert.equals(1, 1.0)
   }
 
-  @Expect(code="shouldHaveAssertInTest", level="warning")
+  @Expect(code="shouldHaveAssertInTest", level="warning", expected="assert")
   test "testForVariable" {
     assert
   }
@@ -76,19 +76,28 @@ describe "asserts unificados" {
     }
   }
 
-  @Expect(code="shouldHaveAssertInTest", level="warning")
+  @Expect(code="shouldHaveAssertInTest", level="warning", expectedOn="const a = 1
+    if (a > 0) assert.equals(a, 1)
+  ")
   test "testNotOkIfWithAssertOnlyInThen" {
     const a = 1
     if (a > 0) assert.equals(a, 1)
   }
 
-  @Expect(code="shouldHaveAssertInTest", level="warning")
+  @Expect(code="shouldHaveAssertInTest", level="warning", expectedOn="var a = 1
+    if (a > 0) { a = a + 1 } else assert.equals(a, 1)
+  ")
   test "testNotOkIfWithAssertOnlyInElse" {
     var a = 1
     if (a > 0) { a = a + 1 } else assert.equals(a, 1)
   }
 
-  @Expect(code="shouldHaveAssertInTest", level="warning")
+  @Expect(code="shouldHaveAssertInTest", level="warning", expectedOn="try {
+      1 / 0
+    } catch e : Exception {
+      1 + 1
+    }
+  ")
   test "testTryCatchWithoutAssert" {
     try {
       1 / 0
@@ -115,7 +124,15 @@ describe "asserts unificados" {
     }
   }
 
-  @Expect(code="shouldHaveAssertInTest", level="warning")
+  @Expect(code="shouldHaveAssertInTest", level="warning", expectedOn="var a = 0
+    try {
+      a = 1
+    } catch e : Exception {
+      a = 2
+    } then always {
+      a = 3
+    }
+  ")
   test "testTryCatchThenAlwaysWithoutAssert" {
     var a = 0
     try {
@@ -132,13 +149,17 @@ describe "asserts unificados" {
     if (a > 0) assert.equals(a, 1) else assert.equals(2, 2)
   }
 
-  @Expect(code="shouldHaveAssertInTest", level="warning")
+  @Expect(code="shouldHaveAssertInTest", level="warning", expectedOn="const a = 1
+    if (a > 0) assert.equals(a, 1)
+  ")
   test "testElseWithoutAssert" {
     const a = 1
     if (a > 0) assert.equals(a, 1)
   }
 
-  @Expect(code="shouldHaveAssertInTest", level="warning")
+  @Expect(code="shouldHaveAssertInTest", level="warning", expectedOn="var a = 1
+    if (a > 0) a = 2 else assert.equals(a, 1)
+  ")
   test "testIfWithoutAssert" {
     var a = 1
     if (a > 0) a = 2 else assert.equals(a, 1)
@@ -158,12 +179,15 @@ describe "asserts unificados" {
     self.bajoEnergia()
   }
 
-  @Expect(code="shouldHaveAssertInTest", level="warning")
+  @Expect(code="shouldHaveAssertInTest", level="warning", expectedOn="ave.planear()
+  ")
   test "al planear sin asserts" {
     ave.planear()
   }
 
-  @Expect(code="shouldHaveAssertInTest", level="warning")
+  @Expect(code="shouldHaveAssertInTest", level="warning", expectedOn="ave.planear()
+    self.preguntarSiBajoEnergia()
+  ")
   test "al planear sin asserts llamando a métodos que no usan assert" {
     ave.planear()
     self.preguntarSiBajoEnergia()

--- a/test/validations/shouldHaveBody.wlk
+++ b/test/validations/shouldHaveBody.wlk
@@ -1,9 +1,9 @@
 object shouldHaveBody {
-  @Expect(code="shouldHaveBody", level="error")
+  @Expect(code="shouldHaveBody", level="error", expectedOn="method noBody()\n")
   method noBody()
 }
 
 const o = object {
-  @Expect(code="shouldHaveBody", level="error")
+  @Expect(code="shouldHaveBody", level="error", expectedOn="method noBody()\n")
   method noBody()
 }

--- a/test/validations/shouldHaveBody.wlk
+++ b/test/validations/shouldHaveBody.wlk
@@ -1,9 +1,9 @@
 object shouldHaveBody {
-  @Expect(code="shouldHaveBody", level="error", expectedOn="method noBody()\n")
+  @Expect(code="shouldHaveBody", level="error", expectedOn="method noBody()")
   method noBody()
 }
 
 const o = object {
-  @Expect(code="shouldHaveBody", level="error", expectedOn="method noBody()\n")
+  @Expect(code="shouldHaveBody", level="error", expectedOn="method noBody()")
   method noBody()
 }

--- a/test/validations/shouldHaveCatchOrAlways.wlk
+++ b/test/validations/shouldHaveCatchOrAlways.wlk
@@ -2,8 +2,7 @@ class BadClass {
   method badTry() {
     @Expect(code="shouldHaveCatchOrAlways", level="error", expectedOn="try {
       return 2
-    }
-  ")
+    }")
     try {
       return 2
     }

--- a/test/validations/shouldHaveCatchOrAlways.wlk
+++ b/test/validations/shouldHaveCatchOrAlways.wlk
@@ -1,6 +1,9 @@
 class BadClass {
   method badTry() {
-    @Expect(code="shouldHaveCatchOrAlways", level="error")
+    @Expect(code="shouldHaveCatchOrAlways", level="error", expectedOn="try {
+      return 2
+    }
+  ")
     try {
       return 2
     }

--- a/test/validations/shouldHaveDifferentName.wtest
+++ b/test/validations/shouldHaveDifferentName.wtest
@@ -1,21 +1,21 @@
-@Expect(code="shouldHaveDifferentName", level="error")
+@Expect(code="shouldHaveDifferentName", level="error", expectedOn="\"a duplicated test\"")
 test "a duplicated test" {
   assert.that(true)
 }
 
-@Expect(code="shouldHaveDifferentName", level="error")
+@Expect(code="shouldHaveDifferentName", level="error", expectedOn="\"a duplicated test\"")
 test "a duplicated test" {
   assert.equals(2, 1 + 1)
 } 
 
 describe "a group of tests" {
 
-  @Expect(code="shouldHaveDifferentName", level="error")
+  @Expect(code="shouldHaveDifferentName", level="error", expectedOn="\"duplicated\"")
   test "duplicated" {
     assert.equals(2, 1 + 1)
   }
 
-  @Expect(code="shouldHaveDifferentName", level="error")
+  @Expect(code="shouldHaveDifferentName", level="error", expectedOn="\"duplicated\"")
   test "duplicated" {
     assert.notThat(false)
   }

--- a/test/validations/shouldHaveNonEmptyName.wtest
+++ b/test/validations/shouldHaveNonEmptyName.wtest
@@ -1,14 +1,14 @@
-@Expect(code = "shouldHaveNonEmptyName", level="warning")
+@Expect(code="shouldHaveNonEmptyName", level="warning", expectedOn="\"\"")
 describe "" {
-  @Expect(code = "shouldHaveNonEmptyName", level="warning")
+  @Expect(code="shouldHaveNonEmptyName", level="warning")
   test "" {
     assert.that(true)
   }
 }
 
-@Expect(code = "shouldHaveNonEmptyName", level="warning")
+@Expect(code="shouldHaveNonEmptyName", level="warning", expectedOn="\"    \"")
 describe "    " {
-  @Expect(code = "shouldHaveNonEmptyName", level="warning")
+  @Expect(code="shouldHaveNonEmptyName", level="warning", expectedOn="\"   \"")
   test "   " {
     assert.that(true)
   }

--- a/test/validations/shouldImplementAllMethodsInHierarchy.wlk
+++ b/test/validations/shouldImplementAllMethodsInHierarchy.wlk
@@ -51,10 +51,10 @@ mixin Doctor {
 	override method name() = "Dr. " + super()
 }
 
-@Expect(code = "shouldImplementAllMethodsInHierarchy", value = "error")
+@Expect(code = "shouldImplementAllMethodsInHierarchy", level = "error")
 class Tomato inherits Doctor {}
 
-@Expect(code = "shouldImplementAllMethodsInHierarchy", value = "error")
+@Expect(code = "shouldImplementAllMethodsInHierarchy", level = "error")
 class TomatoWithNameBelowSuper inherits Doctor {
 	override method name() = "23"
 }
@@ -67,7 +67,7 @@ mixin Named {
 class Person inherits Doctor and Named {}
 
 // NOT OK ! order matters !
-@Expect(code = "shouldImplementAllMethodsInHierarchy", value = "error")
+@Expect(code = "shouldImplementAllMethodsInHierarchy", level = "error")
 class PersonBad inherits Named and Doctor {}
 
 // OK: super method comes from super class
@@ -77,7 +77,7 @@ class WithName {
 class ANamed inherits Doctor and WithName {
 }
 
-@Expect(code = "shouldImplementAllMethodsInHierarchy", value = "error")
+@Expect(code = "shouldImplementAllMethodsInHierarchy", level = "error")
 object o1 inherits Doctor {
 }
 
@@ -88,7 +88,7 @@ object o2 inherits Doctor and WithName {
 // OK
 object o3 inherits Doctor and Named {}
 
-@Expect(code = "shouldImplementAllMethodsInHierarchy", value = "error")
+@Expect(code = "shouldImplementAllMethodsInHierarchy", level = "error")
 object o4 inherits Named and Doctor {}
 
 
@@ -103,12 +103,12 @@ object mixingAtInstantiation {
 		return [
 			// OK
 			object inherits Doctor and WithName {},
-			@Expect(code = "shouldImplementAllMethodsInHierarchy", value = "error")
+			@Expect(code = "shouldImplementAllMethodsInHierarchy", level = "error")
 			object inherits Doctor {},
 			
 			// OK 
 			object inherits Doctor and Named and Pepin {},
-			@Expect(code = "shouldImplementAllMethodsInHierarchy", value = "error")
+			@Expect(code = "shouldImplementAllMethodsInHierarchy", level = "error")
 			object inherits Named and Doctor and Pepin {}
 		]
 	}

--- a/test/validations/shouldInitializeConstant.wpgm
+++ b/test/validations/shouldInitializeConstant.wpgm
@@ -1,4 +1,4 @@
 program p {
-    @Expect(code="shouldInitializeConst", level="error")
+    @Expect(code="shouldInitializeConst", level="error", expectedOn="b")
     const b
 }

--- a/test/validations/shouldInitializeGlobalReference.wlk
+++ b/test/validations/shouldInitializeGlobalReference.wlk
@@ -1,4 +1,4 @@
-@Expect(code="shouldInitializeGlobalReference", level="error")
+@Expect(code="shouldInitializeGlobalReference", level="error", expectedOn="uninitializedVariable")
 const uninitializedVariable
 
 const initializedVariableWithNull = null

--- a/test/validations/shouldInitializeSingletonAttribute.wlk
+++ b/test/validations/shouldInitializeSingletonAttribute.wlk
@@ -1,8 +1,8 @@
 object o {
-  @Expect(code="shouldInitializeSingletonAttribute", level="error")
+  @Expect(code="shouldInitializeSingletonAttribute", level="error", expectedOn="a")
   const a
   const b = 3
-  @Expect(code="shouldInitializeSingletonAttribute", level="error")
+  @Expect(code="shouldInitializeSingletonAttribute", level="error", expectedOn="c")
   const c 
 
   method calculate() = a + b + c

--- a/test/validations/shouldMatchSuperclassReturnValue.wlk
+++ b/test/validations/shouldMatchSuperclassReturnValue.wlk
@@ -5,7 +5,7 @@ class A {
 }
 
 class B inherits A {
-	@Expect(code="shouldMatchSuperclassReturnValue", level="error")
+	@Expect(code="shouldMatchSuperclassReturnValue", level="error", expectedOn="console.println(\"blah\") ")
   override method giveMeANumber() { console.println("blah") }
 }
 
@@ -19,7 +19,7 @@ class D inherits C {
 }
 
 class E inherits D {
-	@Expect(code="shouldMatchSuperclassReturnValue", level="error")
+	@Expect(code="shouldMatchSuperclassReturnValue", level="error", expectedOn="console.println(\"blah\") ")
 	override method giveMeANumber() { console.println("blah") }
 }
 
@@ -37,7 +37,7 @@ class Z {
 }
 
 class Y inherits Z {
-	@Expect(code="shouldMatchSuperclassReturnValue", level="error")
+	@Expect(code="shouldMatchSuperclassReturnValue", level="error", expectedOn="return 23")
 	override method doSomething() {
 		return 23
 	}	

--- a/test/validations/shouldMatchSuperclassReturnValue.wlk
+++ b/test/validations/shouldMatchSuperclassReturnValue.wlk
@@ -37,7 +37,7 @@ class Z {
 }
 
 class Y inherits Z {
-	@Expect(code="shouldMatchSuperclassReturnValue", level="error", expectedOn="return 23")
+	@Expect(code="shouldMatchSuperclassReturnValue", level="error", expectedOn="23")
 	override method doSomething() {
 		return 23
 	}	

--- a/test/validations/shouldNotAssignToItself.wlk
+++ b/test/validations/shouldNotAssignToItself.wlk
@@ -2,7 +2,7 @@ class SomeClass {
   var value = 0
 
   method someMethod() {
-    @Expect(code="shouldNotAssignToItself", level="error")
+    @Expect(code="shouldNotAssignToItself", level="error", expectedOn="value = value")
     value = value
   }
 }

--- a/test/validations/shouldNotAssignToItselfInDeclaration.wlk
+++ b/test/validations/shouldNotAssignToItselfInDeclaration.wlk
@@ -1,5 +1,5 @@
 class SomeClass {
-  @Expect(code = "shouldNotAssignToItselfInDeclaration", level="error")
+  @Expect(code = "shouldNotAssignToItselfInDeclaration", level="error", expectedOn="var attribute = attribute")
   var attribute = attribute
 
   method attribute() = attribute
@@ -9,7 +9,7 @@ class SomeClass {
   }
   
   method someMethod() {
-    @Expect(code = "shouldNotAssignToItselfInDeclaration", level="error")
+    @Expect(code = "shouldNotAssignToItselfInDeclaration", level="error", expectedOn="var localVariable = localVariable")
     var localVariable = localVariable
 
     localVariable = !localVariable

--- a/test/validations/shouldNotCompareAgainstBooleanLiterals.wlk
+++ b/test/validations/shouldNotCompareAgainstBooleanLiterals.wlk
@@ -4,64 +4,64 @@ class SomeClass {
     var cond = true
     
     // TRUE
-    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (condA == true))
+    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="condA == true") (condA == true))
     
-    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (condA === true))
+    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="condA === true") (condA === true))
     
-    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (condA != true))
+    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="condA != true") (condA != true))
     
-    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (condA !== true))
+    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="condA !== true") (condA !== true))
     
-    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (true == condA))
+    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="true == condA") (true == condA))
     
-    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (true === condA))
+    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="true === condA") (true === condA))
     
-    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (true != condA))
+    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="true != condA") (true != condA))
     
-    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (true !== condA))
+    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="true !== condA") (true !== condA))
     
     // FALSE
-    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (condA == false))
+    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="condA == false") (condA == false))
     
-    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (condA === false))
+    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="condA === false") (condA === false))
     
-    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (condA != false))
+    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="condA != false") (condA != false))
     
-    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (condA !== false))
+    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="condA !== false") (condA !== false))
     
-    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (false == condA))
+    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="false == condA") (false == condA))
     
-    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (false === condA))
+    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="false === condA") (false === condA))
     
-    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (false != condA))
+    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="false != condA") (false != condA))
     
-    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (false !== condA))
+    cond = (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="false !== condA") (false !== condA))
     
     // IF
     
-    if (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (cond == true))
+    if (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="cond == true") (cond == true))
       throw new Exception(message = "Blah")
 
-    if (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (cond == false))
+    if (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="cond == false") (cond == false))
       throw new Exception(message = "Blah")
       
-    if (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (cond != true))
+    if (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="cond != true") (cond != true))
       throw new Exception(message = "Blah")
 
-    if (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (cond != false))
+    if (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="cond != false") (cond != false))
       throw new Exception(message = "Blah")
       
-    if (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (cond !== true))
+    if (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="cond !== true") (cond !== true))
       throw new Exception(message = "Blah")
 
-    if (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (cond !== false))
+    if (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="cond !== false") (cond !== false))
       throw new Exception(message = "Blah")    
       
     // if as left side
-    if (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (true == cond))
+    if (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="true == cond") (true == cond))
       throw new Exception(message = "Blah")
 
-    if (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning") (false == cond))
+    if (@Expect(code="shouldNotCompareAgainstBooleanLiterals", level="warning", expectedOn="false == cond") (false == cond))
       throw new Exception(message = "Blah")
   }
 }

--- a/test/validations/shouldNotCompareEqualityOfSingleton.wlk
+++ b/test/validations/shouldNotCompareEqualityOfSingleton.wlk
@@ -7,13 +7,13 @@ object pepita {
   var energia = 100
   
   method comer(que) {
-    if (@Expect(code="shouldNotCompareEqualityOfSingleton", level="warning") (que == alpiste)) {
+    if (@Expect(code="shouldNotCompareEqualityOfSingleton", level="warning", expectedOn="que == alpiste") (que == alpiste)) {
       energia += 5
     }
 
-    if (@Expect(code="shouldNotCompareEqualityOfSingleton", level="warning") (mijo == que)) {
+    if (@Expect(code="shouldNotCompareEqualityOfSingleton", level="warning", expectedOn="mijo == que") (mijo == que)) {
       energia += 5
-    } else if (@Expect(code="shouldNotCompareEqualityOfSingleton", level="warning") (que === manzana))
+    } else if (@Expect(code="shouldNotCompareEqualityOfSingleton", level="warning", expectedOn="que === manzana") (que === manzana))
         energia +=80
 
     // OK

--- a/test/validations/shouldNotDefineEmptyDescribe.wtest
+++ b/test/validations/shouldNotDefineEmptyDescribe.wtest
@@ -1,2 +1,2 @@
-@Expect(code="shouldNotDefineEmptyDescribe", level="warning")
+@Expect(code="shouldNotDefineEmptyDescribe", level="warning", expectedOn="describe \"empty\" {}")
 describe "empty" {}

--- a/test/validations/shouldNotDefineGlobalMutableVariables.wpgm
+++ b/test/validations/shouldNotDefineGlobalMutableVariables.wpgm
@@ -1,4 +1,4 @@
-@Expect(code="shouldNotDefineGlobalMutableVariables", level="error")
+@Expect(code="shouldNotDefineGlobalMutableVariables", level="error", expectedOn="variableGlobalNotAllowed")
 var variableGlobalNotAllowed = 1
 
 // OK

--- a/test/validations/shouldNotDefineNativeMethodsOnUnnamedSingleton.wlk
+++ b/test/validations/shouldNotDefineNativeMethodsOnUnnamedSingleton.wlk
@@ -1,5 +1,5 @@
 const pepita = object {
-  @Expect(code="shouldNotDefineNativeMethodsOnUnnamedSingleton", level="error")
+  @Expect(code="shouldNotDefineNativeMethodsOnUnnamedSingleton", level="error", expectedOn="fly")
   method fly() native
 }
 

--- a/test/validations/shouldNotDefineUnnecesaryIf.wlk
+++ b/test/validations/shouldNotDefineUnnecesaryIf.wlk
@@ -3,7 +3,7 @@ object pepita {
 
 object p {
   method run() {
-    @Expect(code="shouldNotDefineUnnecesaryIf", level="error")
+    @Expect(code="shouldNotDefineUnnecesaryIf", level="error", expectedOn="true")
     if (true)
       throw new Exception(message = "asd")
   }

--- a/test/validations/shouldNotDefineUnnecessaryCondition.wlk
+++ b/test/validations/shouldNotDefineUnnecessaryCondition.wlk
@@ -4,8 +4,7 @@ object someObject {
     @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning", expectedOn="if (n % 2 == 0)
       return false
     else
-      return false
-  ")
+      return false")
     if (n % 2 == 0)
       return false
     else
@@ -16,8 +15,7 @@ object someObject {
     @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning", expectedOn="if (n % 2 == 0)
       return true
     else
-      return true
-  ")
+      return true")
     if (n % 2 == 0)
       return true
     else
@@ -28,8 +26,7 @@ object someObject {
     return @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning", expectedOn="if (n % 2 == 0)
       { return true }
     else
-      { return true }
-  ") if (n % 2 == 0)
+      { return true }") if (n % 2 == 0)
       { return true }
     else
       { return true }

--- a/test/validations/shouldNotDefineUnnecessaryCondition.wlk
+++ b/test/validations/shouldNotDefineUnnecessaryCondition.wlk
@@ -1,7 +1,11 @@
 object someObject {
   
   method unnecesaryIfBothReturnFalse(n) {
-    @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning")
+    @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning", expectedOn="if (n % 2 == 0)
+      return false
+    else
+      return false
+  ")
     if (n % 2 == 0)
       return false
     else
@@ -9,7 +13,11 @@ object someObject {
   }
 
   method unnecesaryIfBothReturnTrue(n) {
-    @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning")
+    @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning", expectedOn="if (n % 2 == 0)
+      return true
+    else
+      return true
+  ")
     if (n % 2 == 0)
       return true
     else
@@ -17,7 +25,11 @@ object someObject {
   }
 
   method unnecesaryIfBothReturnTrueFirstExpression(n) {
-    return @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning") if (n % 2 == 0)
+    return @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning", expectedOn="if (n % 2 == 0)
+      { return true }
+    else
+      { return true }
+  ") if (n % 2 == 0)
       { return true }
     else
       { return true }
@@ -32,23 +44,23 @@ object p {
     //
     // AND
     //
-    cond = @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning") (true && algo)
+    cond = @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning", expectedOn="true && algo") (true && algo)
 
-    cond = @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning") (true and algo)
+    cond = @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning", expectedOn="true and algo") (true and algo)
 
-    cond = @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning") (algo && true)
+    cond = @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning", expectedOn="algo && true") (algo && true)
     
-    cond = @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning") (algo and true)
+    cond = @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning", expectedOn="algo and true") (algo and true)
 
     //
     // OR
     //
-    cond = @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning") (false || algo)
+    cond = @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning", expectedOn="false || algo") (false || algo)
     
-    cond = @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning") (false or algo)
+    cond = @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning", expectedOn="false or algo") (false or algo)
 
-    cond = @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning") (algo || false)
+    cond = @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning", expectedOn="algo || false") (algo || false)
 
-    cond = @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning") (algo or false)
+    cond = @Expect(code="shouldNotDefineUnnecessaryCondition", level="warning", expectedOn="algo or false") (algo or false)
   }
 }

--- a/test/validations/shouldNotDefineUnusedVariables.wlk
+++ b/test/validations/shouldNotDefineUnusedVariables.wlk
@@ -1,5 +1,5 @@
 class SomeClass {
-  @Expect(code="shouldNotDefineUnusedVariables", level="warning")
+  @Expect(code="shouldNotDefineUnusedVariables", level="warning", expectedOn="unusedVariable")
   var unusedVariable = 0
   const usedVariable = 1000
 
@@ -7,7 +7,7 @@ class SomeClass {
 }
 
 object someObject {
-  @Expect(code="shouldNotDefineUnusedVariables", level="warning")
+  @Expect(code="shouldNotDefineUnusedVariables", level="warning", expectedOn="unusedVariable")
   var unusedVariable = object {}
   const usedVariable = 1000
 

--- a/test/validations/shouldNotDuplicateEntities.wpgm
+++ b/test/validations/shouldNotDuplicateEntities.wpgm
@@ -1,18 +1,18 @@
 import shouldNotDuplicateEntitiesImport.*
 
-@Expect(code = "shouldNotDuplicateEntities", level = "error")
+@Expect(code = "shouldNotDuplicateEntities", level = "error", expectedOn="SomeExistingClassInAnotherImportedFile")
 class SomeExistingClassInAnotherImportedFile {}
 
-@Expect(code = "shouldNotDuplicateEntities", level = "error")
+@Expect(code = "shouldNotDuplicateEntities", level = "error", expectedOn="someExistingObjectInAnotherImportedFile")
 object someExistingObjectInAnotherImportedFile {}
 
-@Expect(code = "shouldNotDuplicateEntities", level = "error")
+@Expect(code = "shouldNotDuplicateEntities", level = "error", expectedOn="someExistingConstInAnotherImportedFile")
 const someExistingConstInAnotherImportedFile = 1
 
-@Expect(code = "shouldNotDuplicateEntities", level = "error")
+@Expect(code = "shouldNotDuplicateEntities", level = "error", expectedOn="SomeExistingMixinInAnotherImportedFile")
 mixin SomeExistingMixinInAnotherImportedFile {}
 
-@Expect(code = "shouldNotDuplicateEntities", level = "error")
+@Expect(code = "shouldNotDuplicateEntities", level = "error", expectedOn="anotherExistingObjectInAnotherImportedFile")
 program anotherExistingObjectInAnotherImportedFile {
     anotherExistingObjectInAnotherImportedFile // ok?
 }

--- a/test/validations/shouldNotDuplicateFields.wlk
+++ b/test/validations/shouldNotDuplicateFields.wlk
@@ -5,7 +5,7 @@ class Levadura {
 }
 
 class Ale inherits Levadura {
-	@Expect(code="shouldNotDuplicateFields", level="error")
+	@Expect(code="shouldNotDuplicateFields", level="error", expectedOn="biomasa")
 	const biomasa = 200
 	
 	method algoConBiomasaParaEvitarWarning() {
@@ -21,7 +21,7 @@ class B inherits Levadura {
  * self one duplicates a var that is two levels up
  */
 class C inherits B {
-	@Expect(code="shouldNotDuplicateFields", level="error")
+	@Expect(code="shouldNotDuplicateFields", level="error", expectedOn="biomasa")
 	const biomasa = 200
 	
 		method algoConBiomasaParaEvitarWarning() {
@@ -31,7 +31,7 @@ class C inherits B {
 
 // same for objects
 object anObject inherits Levadura {
-	@Expect(code="shouldNotDuplicateFields", level="error")
+	@Expect(code="shouldNotDuplicateFields", level="error", expectedOn="biomasa")
 	const biomasa = 200
 	
 		method algoConBiomasaParaEvitarWarning() {
@@ -51,6 +51,6 @@ mixin Volador {
 
 // the singleton definition is ok since the problem will appear on the variable definition
 object pepona inherits Volador and Ave {
-  @Expect(code="shouldNotDuplicateFields", level="error")
+  @Expect(code="shouldNotDuplicateFields", level="error", expectedOn="energia")
   var property energia = 120
 }

--- a/test/validations/shouldNotDuplicateGlobalDefinitions.wtest
+++ b/test/validations/shouldNotDuplicateGlobalDefinitions.wtest
@@ -10,32 +10,38 @@ const repeatedObject = 1
 @Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
 const repeatedObject = 1
 
-@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
+@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="A")
 class A {}
 
-@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
+@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="A")
 class A {}
 
-@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
+@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="Repeated")
 class Repeated {}
 
-@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
+@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="Repeated")
 mixin Repeated {}
 
-@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
+@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="M")
 mixin M {}
 
-@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
+@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="M")
 mixin M {}
 
-@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
+@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="T")
+class T {}
+
+@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="T")
+mixin T {}
+
+@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="\"Fake describe\"")
 describe "Fake describe" {
   test "fake test" {
     assert.that(true)
   }
 }
 
-@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
+@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="\"Fake describe\"")
 describe "Fake describe" {
   test "another fake test" {
     assert.that(true)
@@ -43,21 +49,27 @@ describe "Fake describe" {
 }
 
 package solution {
-  @Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
+  @Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="RepeatedClass")
   class RepeatedClass {}
 
-  @Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
+  @Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="RepeatedClass")
   class RepeatedClass {}
 
-  @Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
+  @Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="RepeatedMixin")
   mixin RepeatedMixin {}
 
-  @Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
+  @Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="RepeatedMixin")
   mixin RepeatedMixin {}
 
-  @Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
+  @Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="R")
+  mixin R {}
+
+  @Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="R")
+  class R {}
+
+  @Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="repeatedObject1")
   const repeatedObject1 = 1
 
-  @Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
+  @Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="repeatedObject1")
   object repeatedObject1 {}
 }

--- a/test/validations/shouldNotDuplicateGlobalDefinitions.wtest
+++ b/test/validations/shouldNotDuplicateGlobalDefinitions.wtest
@@ -1,13 +1,13 @@
-@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
+@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="y")
 const y = 1
 
-@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
+@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="y")
 object y {}
 
-@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
+@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="repeatedObject")
 const repeatedObject = 1
 
-@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error")
+@Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="repeatedObject")
 const repeatedObject = 1
 
 @Expect(code="shouldNotDuplicateGlobalDefinitions", level="error", expectedOn="A")

--- a/test/validations/shouldNotDuplicateLocalVariables.wtest
+++ b/test/validations/shouldNotDuplicateLocalVariables.wtest
@@ -2,13 +2,13 @@ class Person {
   var property toBeHidden = 23
   
   method hidingFieldWithLocalVar() {
-    @Expect(code="shouldNotDuplicateLocalVariables", level="error")
+    @Expect(code="shouldNotDuplicateLocalVariables", level="error", expectedOn="toBeHidden")
     var toBeHidden = 22
     return toBeHidden
   }
   
   method hidingParameterWithLocalVar(p1) {
-    @Expect(code="shouldNotDuplicateLocalVariables", level="error")
+    @Expect(code="shouldNotDuplicateLocalVariables", level="error", expectedOn="p1")
     var p1 = 23
     return p1
   }
@@ -17,10 +17,10 @@ class Person {
 
 class DuplicatedChecksTest {
   method run() {
-    @Expect(code="shouldNotDuplicateLocalVariables", level="error")
+    @Expect(code="shouldNotDuplicateLocalVariables", level="error", expectedOn="u")
     const u = 23
   
-    @Expect(code="shouldNotDuplicateLocalVariables", level="error")
+    @Expect(code="shouldNotDuplicateLocalVariables", level="error", expectedOn="u")
     const u = 566
   }
 }
@@ -30,14 +30,14 @@ describe "pruebas generales" {
   const b = 3
 	
 	test "Max between 5 and 8 - using vars" {
-		@Expect(code="shouldNotDuplicateLocalVariables", level="error")
+		@Expect(code="shouldNotDuplicateLocalVariables", level="error", expectedOn="a")
 		const a = 3
 		const result = 5.max(a)
 		assert.equals(3, result)
 	}
 
   test "Max between 5 and 8 - using consts" {
-		@Expect(code="shouldNotDuplicateLocalVariables", level="error")
+		@Expect(code="shouldNotDuplicateLocalVariables", level="error", expectedOn="b")
 		const b = 3
 		const result = 5.max(b)
 		assert.equals(3, result)

--- a/test/validations/shouldNotDuplicatePackageName.wlk
+++ b/test/validations/shouldNotDuplicatePackageName.wlk
@@ -1,8 +1,8 @@
-@Expect(code = "shouldNotDuplicatePackageName", level="error")
+@Expect(code = "shouldNotDuplicatePackageName", level="error", expectedOn="otherPackage")
 package otherPackage {
 	class A {}
 }
 
-@Expect(code = "shouldNotDuplicatePackageName", level="error")
+@Expect(code = "shouldNotDuplicatePackageName", level="error", expectedOn="otherPackage")
 package otherPackage {}
 

--- a/test/validations/shouldNotDuplicateVariablesInLinearization.wlk
+++ b/test/validations/shouldNotDuplicateVariablesInLinearization.wlk
@@ -13,14 +13,10 @@ mixin Volador {
   method volar() { kilometros = kilometros + 100 }
 }
 
-@Expect(code="shouldNotDuplicateVariablesInLinearization", level="error", expectedOn="object pepita inherits Caminante and Volador and Ave {}
-
-")
+@Expect(code="shouldNotDuplicateVariablesInLinearization", level="error", expectedOn="object pepita inherits Caminante and Volador and Ave {}")
 object pepita inherits Caminante and Volador and Ave {}
 
 const avecita = 
-  @Expect(code="shouldNotDuplicateVariablesInLinearization", level="error", expectedOn="object inherits Caminante and Volador and Ave {}
-
-")
+  @Expect(code="shouldNotDuplicateVariablesInLinearization", level="error", expectedOn="object inherits Caminante and Volador and Ave {}")
   object inherits Caminante and Volador and Ave {}
 

--- a/test/validations/shouldNotDuplicateVariablesInLinearization.wlk
+++ b/test/validations/shouldNotDuplicateVariablesInLinearization.wlk
@@ -13,10 +13,14 @@ mixin Volador {
   method volar() { kilometros = kilometros + 100 }
 }
 
-@Expect(code="shouldNotDuplicateVariablesInLinearization", level="error")
+@Expect(code="shouldNotDuplicateVariablesInLinearization", level="error", expectedOn="object pepita inherits Caminante and Volador and Ave {}
+
+")
 object pepita inherits Caminante and Volador and Ave {}
 
 const avecita = 
-  @Expect(code="shouldNotDuplicateVariablesInLinearization", level="error")
+  @Expect(code="shouldNotDuplicateVariablesInLinearization", level="error", expectedOn="object inherits Caminante and Volador and Ave {}
+
+")
   object inherits Caminante and Volador and Ave {}
 

--- a/test/validations/shouldNotImportMoreThanOnce2.wlk
+++ b/test/validations/shouldNotImportMoreThanOnce2.wlk
@@ -1,5 +1,5 @@
 import shouldNotImportMoreThanOnceImport.*
-@Expect(code = "shouldNotImportMoreThanOnce", level = "warning")
+@Expect(code = "shouldNotImportMoreThanOnce", level = "warning", expectedOn = "import shouldNotImportMoreThanOnceImport.AnotherClass")
 import shouldNotImportMoreThanOnceImport.AnotherClass
 
 class CallingClass {

--- a/test/validations/shouldNotImportMoreThanOnce3.wlk
+++ b/test/validations/shouldNotImportMoreThanOnce3.wlk
@@ -1,4 +1,4 @@
-@Expect(code = "shouldNotImportMoreThanOnce", level = "warning")
+@Expect(code = "shouldNotImportMoreThanOnce", level = "warning", expectedOn = "import shouldNotImportMoreThanOnceImport.AnotherClass")
 import shouldNotImportMoreThanOnceImport.AnotherClass
 import shouldNotImportMoreThanOnceImport.*
 

--- a/test/validations/shouldNotImportMoreThanOnce4.wlk
+++ b/test/validations/shouldNotImportMoreThanOnce4.wlk
@@ -1,6 +1,6 @@
-@Expect(code = "shouldNotImportMoreThanOnce", level = "warning")
+@Expect(code = "shouldNotImportMoreThanOnce", level = "warning", expectedOn = "import shouldNotImportMoreThanOnceImport.*")
 import shouldNotImportMoreThanOnceImport.*
-@Expect(code = "shouldNotImportMoreThanOnce", level = "warning")
+@Expect(code = "shouldNotImportMoreThanOnce", level = "warning", expectedOn = "import shouldNotImportMoreThanOnceImport.*")
 import shouldNotImportMoreThanOnceImport.*
 
 class CallingClass {

--- a/test/validations/shouldNotImportSameFile.wlk
+++ b/test/validations/shouldNotImportSameFile.wlk
@@ -1,2 +1,2 @@
-@Expect(code = "shouldNotImportSameFile", level = "error")
+@Expect(code = "shouldNotImportSameFile", level = "error", expectedOn="import shouldNotImportSameFile.*")
 import shouldNotImportSameFile.*

--- a/test/validations/shouldNotInstantiateAbstractClass.wlk
+++ b/test/validations/shouldNotInstantiateAbstractClass.wlk
@@ -9,7 +9,7 @@ class ConcreteClass inherits AbstractClass {
 
 class SomeClass {
   method something(param) {
-    const value = @Expect(code="shouldNotInstantiateAbstractClass", level="error") new AbstractClass()
+    const value = @Expect(code="shouldNotInstantiateAbstractClass", level="error", expectedOn="new AbstractClass()\n    ") new AbstractClass()
     const anotherValue = new ConcreteClass()
     return if (param) value.concreteMethod() else anotherValue.abstractMethod()
   }

--- a/test/validations/shouldNotInstantiateAbstractClass.wlk
+++ b/test/validations/shouldNotInstantiateAbstractClass.wlk
@@ -9,7 +9,7 @@ class ConcreteClass inherits AbstractClass {
 
 class SomeClass {
   method something(param) {
-    const value = @Expect(code="shouldNotInstantiateAbstractClass", level="error", expectedOn="new AbstractClass()\n    ") new AbstractClass()
+    const value = @Expect(code="shouldNotInstantiateAbstractClass", level="error", expectedOn="new AbstractClass()") new AbstractClass()
     const anotherValue = new ConcreteClass()
     return if (param) value.concreteMethod() else anotherValue.abstractMethod()
   }

--- a/test/validations/shouldNotMarkMoreThanOneOnlyTestDescribe.wtest
+++ b/test/validations/shouldNotMarkMoreThanOneOnlyTestDescribe.wtest
@@ -1,16 +1,16 @@
 describe "a group of tests for the only flag" {
 	
-	@Expect(code="shouldNotMarkMoreThanOneOnlyTest", level="warning")
+	@Expect(code="shouldNotMarkMoreThanOneOnlyTest", level="warning", expectedOn="only")
 	only test "truthy test" {
 		assert.that(true)
 	}
 	
-	@Expect(code="shouldNotMarkMoreThanOneOnlyTest", level="warning")
+	@Expect(code="shouldNotMarkMoreThanOneOnlyTest", level="warning", expectedOn="only")
 	only test "equality for numbers" {
 		assert.equals(1, 1.0)
 	}
 	
-	@Expect(code="shouldNotMarkMoreThanOneOnlyTest", level="warning")
+	@Expect(code="shouldNotMarkMoreThanOneOnlyTest", level="warning", expectedOn="only")
 	only test "falsy test" {
 		assert.notThat(false)
 	}

--- a/test/validations/shouldNotMarkMoreThanOneOnlyTestIndividual.wtest
+++ b/test/validations/shouldNotMarkMoreThanOneOnlyTestIndividual.wtest
@@ -1,16 +1,16 @@
 import wollok.lib.assert
 
-@Expect(code="shouldNotMarkMoreThanOneOnlyTest", level="warning")
+@Expect(code="shouldNotMarkMoreThanOneOnlyTest", level="warning", expectedOn="only")
 only test "truthy test" {
 	assert.that(true)
 }
 
-@Expect(code="shouldNotMarkMoreThanOneOnlyTest", level="warning")
+@Expect(code="shouldNotMarkMoreThanOneOnlyTest", level="warning", expectedOn="only")
 only test "equality for numbers" {
 	assert.equals(1, 1.0)
 }
 
-@Expect(code="shouldNotMarkMoreThanOneOnlyTest", level="warning")
+@Expect(code="shouldNotMarkMoreThanOneOnlyTest", level="warning", expectedOn="only")
 only test "falsy test" {
 	assert.notThat(false)
 }

--- a/test/validations/shouldNotOnlyCallToSuper.wlk
+++ b/test/validations/shouldNotOnlyCallToSuper.wlk
@@ -58,7 +58,9 @@ class GolondrinaSarasa inherits Golondrina {
         return super()
     }
 
-  @Expect(code="shouldNotOnlyCallToSuper", level="warning")
+  @Expect(code="shouldNotOnlyCallToSuper", level="warning", expectedOn="super()
+
+  ")
   override method estasAlegre() = super()
 
   override method estasPensativa() = !super()

--- a/test/validations/shouldNotOnlyCallToSuper.wlk
+++ b/test/validations/shouldNotOnlyCallToSuper.wlk
@@ -58,9 +58,7 @@ class GolondrinaSarasa inherits Golondrina {
         return super()
     }
 
-  @Expect(code="shouldNotOnlyCallToSuper", level="warning", expectedOn="super()
-
-  ")
+  @Expect(code="shouldNotOnlyCallToSuper", level="warning", expectedOn="super()")
   override method estasAlegre() = super()
 
   override method estasPensativa() = !super()

--- a/test/validations/shouldNotReassignConst.wlk
+++ b/test/validations/shouldNotReassignConst.wlk
@@ -18,7 +18,7 @@ class SomeClass {
       @Expect(code = "shouldNotReassignConst", level = "error", expectedOn = "a = 23")
       a = 23
     }
-    @Expect(code = "shouldNotReassignConst", level = "error", expectedOn = "aBlock = null\n  ")
+    @Expect(code = "shouldNotReassignConst", level = "error", expectedOn = "aBlock = null")
     aBlock = null
   }
   

--- a/test/validations/shouldNotReassignConst.wlk
+++ b/test/validations/shouldNotReassignConst.wlk
@@ -8,22 +8,22 @@ class SomeClass {
   var varReference = 1
 
   method tryingToChangeConstReference() {
-    @Expect(code = "shouldNotReassignConst", level = "error")
+    @Expect(code = "shouldNotReassignConst", level = "error", expectedOn = "constReference = 2")
     constReference = 2
     varReference = 2
   }
 
   method methodWithBlock() {
     const aBlock = { a =>
-      @Expect(code = "shouldNotReassignConst", value = "error", expectedOn = "a")
+      @Expect(code = "shouldNotReassignConst", level = "error", expectedOn = "a = 23")
       a = 23
     }
-    @Expect(code = "shouldNotReassignConst", value = "error", expectedOn = "aBlock")
+    @Expect(code = "shouldNotReassignConst", level = "error", expectedOn = "aBlock = null\n  ")
     aBlock = null
   }
   
   method methodWithParam(aParam) {
-    @Expect(code = "shouldNotReassignConst", value = "error", expectedOn = "aParam")
+    @Expect(code = "shouldNotReassignConst", level = "error", expectedOn = "aParam = 23")
     aParam = 23
   }
 
@@ -38,7 +38,7 @@ class A {
   const property a = 2
   
   override method initialize() {
-    @Expect(code = "shouldNotReassignConst", value = "error", expectedOn = "a")
+    @Expect(code = "shouldNotReassignConst", level = "error", expectedOn = "a = 1")
     a = 1
   }
 }
@@ -57,7 +57,7 @@ class C {
   const property b
   
   override method initialize() {
-    @Expect(code = "shouldNotReassignConst", value = "error", expectedOn = "b")
+    @Expect(code = "shouldNotReassignConst", level = "error", expectedOn = "b = a + 1")
     b = a + 1
   }
 }
@@ -73,10 +73,10 @@ class MultiOpsOperations {
     n = n + 1  // OK
     
     const m = 1
-    @Expect(code = "shouldNotReassignConst", value = "error", expectedOn = "m")
+    @Expect(code = "shouldNotReassignConst", level = "error", expectedOn = "m -= 3")
     m -= 3
 
-    @Expect(code = "shouldNotReassignConst", value = "error", expectedOn = "m")
+    @Expect(code = "shouldNotReassignConst", level = "error", expectedOn = "m += 3")
     m += 3
   }  
 }

--- a/test/validations/shouldNotReassignConst.wlk
+++ b/test/validations/shouldNotReassignConst.wlk
@@ -8,22 +8,22 @@ class SomeClass {
   var varReference = 1
 
   method tryingToChangeConstReference() {
-    @Expect(code = "shouldNotReassignConst", value = "error")
+    @Expect(code = "shouldNotReassignConst", level = "error")
     constReference = 2
     varReference = 2
   }
 
   method methodWithBlock() {
     const aBlock = { a =>
-      @Expect(code = "shouldNotReassignConst", value = "error")
+      @Expect(code = "shouldNotReassignConst", value = "error", expectedOn = "a")
       a = 23
     }
-    @Expect(code = "shouldNotReassignConst", value = "error")
+    @Expect(code = "shouldNotReassignConst", value = "error", expectedOn = "aBlock")
     aBlock = null
   }
   
   method methodWithParam(aParam) {
-    @Expect(code = "shouldNotReassignConst", value = "error")
+    @Expect(code = "shouldNotReassignConst", value = "error", expectedOn = "aParam")
     aParam = 23
   }
 
@@ -38,7 +38,7 @@ class A {
   const property a = 2
   
   override method initialize() {
-    @Expect(code = "shouldNotReassignConst", value = "error")
+    @Expect(code = "shouldNotReassignConst", value = "error", expectedOn = "a")
     a = 1
   }
 }
@@ -57,7 +57,7 @@ class C {
   const property b
   
   override method initialize() {
-    @Expect(code = "shouldNotReassignConst", value = "error")
+    @Expect(code = "shouldNotReassignConst", value = "error", expectedOn = "b")
     b = a + 1
   }
 }
@@ -73,10 +73,10 @@ class MultiOpsOperations {
     n = n + 1  // OK
     
     const m = 1
-    @Expect(code = "shouldNotReassignConst", value = "error")
+    @Expect(code = "shouldNotReassignConst", value = "error", expectedOn = "m")
     m -= 3
 
-    @Expect(code = "shouldNotReassignConst", value = "error")
+    @Expect(code = "shouldNotReassignConst", value = "error", expectedOn = "m")
     m += 3
   }  
 }

--- a/test/validations/shouldNotUseOverride.wlk
+++ b/test/validations/shouldNotUseOverride.wlk
@@ -13,12 +13,12 @@ object foo {
 }
 
 class Bar {
-  @Expect(code = "shouldNotUseOverride", level = "error")
+  @Expect(code = "shouldNotUseOverride", level = "error", expectedOn = "override")
   override method fafafa() {}
 }
 
 object bar {
-  @Expect(code = "shouldNotUseOverride", level = "error")
+  @Expect(code = "shouldNotUseOverride", level = "error", expectedOn = "override")
   override method fafafa() {}
 }
 
@@ -33,11 +33,11 @@ class SpecialList inherits List {
   override method remove (other) {
   }
     
-  @Expect(code = "shouldNotUseOverride", level = "error")
+  @Expect(code = "shouldNotUseOverride", level = "error", expectedOn = "override")
   override method fafafa() {}
 }
 
 object barList inherits List {
-  @Expect(code = "shouldNotUseOverride", level = "error")
+  @Expect(code = "shouldNotUseOverride", level = "error", expectedOn = "override")
   override method fafafa() {}
 }

--- a/test/validations/shouldNotUseReservedWords.wpgm
+++ b/test/validations/shouldNotUseReservedWords.wpgm
@@ -1,25 +1,25 @@
-@Expect(code = "shouldNotUseReservedWords", value = "warning", expectedOn = "Object")
+@Expect(code = "shouldNotUseReservedWords", level = "warning", expectedOn = "Object")
 class Object { }
 
-@Expect(code = "shouldNotUseReservedWords", value = "warning", expectedOn = "List")
+@Expect(code = "shouldNotUseReservedWords", level = "warning", expectedOn = "List")
 class List { }
 
-@Expect(code = "shouldNotUseReservedWords", value = "warning", expectedOn = "assert")
+@Expect(code = "shouldNotUseReservedWords", level = "warning", expectedOn = "assert")
 object assert {}
 
-@Expect(code = "shouldNotUseReservedWords", value = "warning", expectedOn = "console")
+@Expect(code = "shouldNotUseReservedWords", level = "warning", expectedOn = "console")
 const console = object {}
 
 class A {
-  @Expect(code = "shouldNotUseReservedWords", value = "warning", expectedOn = "assert")
+  @Expect(code = "shouldNotUseReservedWords", level = "warning", expectedOn = "assert")
   var assert = 5
 
-  method someMethod(@Expect(code = "shouldNotUseReservedWords", value = "warning", expectedOn = "console") console) {
+  method someMethod(@Expect(code = "shouldNotUseReservedWords", level = "warning", expectedOn = "console") console) {
     assert.that(true)
   }
 }
 
-@Expect(code = "shouldNotUseReservedWords", value = "warning", expectedOn = "wollok")
+@Expect(code = "shouldNotUseReservedWords", level = "warning", expectedOn = "wollok")
 const wollok = 11
 
 

--- a/test/validations/shouldNotUseReservedWords.wpgm
+++ b/test/validations/shouldNotUseReservedWords.wpgm
@@ -1,29 +1,29 @@
-@Expect(code = "shouldNotUseReservedWords", value = "warning")
+@Expect(code = "shouldNotUseReservedWords", value = "warning", expectedOn = "Object")
 class Object { }
 
-@Expect(code = "shouldNotUseReservedWords", value = "warning")
+@Expect(code = "shouldNotUseReservedWords", value = "warning", expectedOn = "List")
 class List { }
 
-@Expect(code = "shouldNotUseReservedWords", value = "warning")
+@Expect(code = "shouldNotUseReservedWords", value = "warning", expectedOn = "assert")
 object assert {}
 
-@Expect(code = "shouldNotUseReservedWords", value = "warning")
+@Expect(code = "shouldNotUseReservedWords", value = "warning", expectedOn = "console")
 const console = object {}
 
 class A {
-  @Expect(code = "shouldNotUseReservedWords", value = "warning")
+  @Expect(code = "shouldNotUseReservedWords", value = "warning", expectedOn = "assert")
   var assert = 5
 
-  method someMethod(@Expect(code = "shouldNotUseReservedWords", value = "warning") console) {
+  method someMethod(@Expect(code = "shouldNotUseReservedWords", value = "warning", expectedOn = "console") console) {
     assert.that(true)
   }
 }
 
-@Expect(code = "shouldNotUseReservedWords", value = "warning")
-const wollok =11
+@Expect(code = "shouldNotUseReservedWords", value = "warning", expectedOn = "wollok")
+const wollok = 11
 
 
-@Expect(code="shouldNotUseReservedWords", level="warning")
+@Expect(code="shouldNotUseReservedWords", level="warning", expectedOn = "game")
 program game {
   console.println(game) // ok?
 }

--- a/test/validations/shouldNotUseSelf.wpgm
+++ b/test/validations/shouldNotUseSelf.wpgm
@@ -5,20 +5,20 @@ class SomeClass {
 program main {
   const someVariable = 2
 
-  @Expect(code="shouldNotUseSelf", level="error")
+  @Expect(code="shouldNotUseSelf", level="error", expectedOn="self")
   self.println()
 
   const a = true
   if (a) {
-    @Expect(code="shouldNotUseSelf", level="error")
+    @Expect(code="shouldNotUseSelf", level="error", expectedOn="self")
     self.println()
   }
 
-  2 + @Expect(code="shouldNotUseSelf", level="error") self.someVariable()
+  2 + @Expect(code="shouldNotUseSelf", level="error", expectedOn="self") self.someVariable()
 
   const collection1 = ['a', 'b', 'c']
    
-  collection1.contains(@Expect(code="shouldNotUseSelf", level="error") self)
+  collection1.contains(@Expect(code="shouldNotUseSelf", level="error", expectedOn="self") self)
 
   const anObject = object {
     method aMethod() {
@@ -28,5 +28,5 @@ program main {
   }
   console.println(anObject.aMethod())
 
-  console.println(@Expect(code="shouldNotUseSelf", level="error") self.someVariable())
+  console.println(@Expect(code="shouldNotUseSelf", level="error", expectedOn="self") self.someVariable())
 }

--- a/test/validations/shouldNotUseVoidMethodAsValue.wlk
+++ b/test/validations/shouldNotUseVoidMethodAsValue.wlk
@@ -18,11 +18,11 @@ class MethodsCalledOnWellKnowObjects inherits A {
 
 	
 	method asParameter() {
-		self.setA(@Expect(code = "shouldNotUseVoidMethodAsValue", message = "error") (pepita.ingest(10)))
+		self.setA(@Expect(code = "shouldNotUseVoidMethodAsValue", message = "error", expected="pepita.ingest(10)") (pepita.ingest(10)))
 	}
 	
 	method initialization(aParam) {
-		const a = @Expect(code = "shouldNotUseVoidMethodAsValue", message = "error") (pepita.ingest(10))
+		const a = @Expect(code = "shouldNotUseVoidMethodAsValue", message = "error", expected="pepita.ingest(10)") (pepita.ingest(10))
 		
 		self.setA(a)
 	}
@@ -30,17 +30,17 @@ class MethodsCalledOnWellKnowObjects inherits A {
 	method assignment(aParam) {
 		var a = null
 		
-		a = @Expect(code = "shouldNotUseVoidMethodAsValue", message = "error") (pepita.ingest(10))
+		a = @Expect(code = "shouldNotUseVoidMethodAsValue", message = "error", expected="pepita.ingest(10)") (pepita.ingest(10))
 		
 		self.setA(a)
 	}
 	
 	method asReturnValue() {
-		return @Expect(code = "shouldNotUseVoidMethodAsValue", message = "error") (pepita.ingest(10))
+		return @Expect(code = "shouldNotUseVoidMethodAsValue", message = "error", expected="pepita.ingest(10)") (pepita.ingest(10))
 	}
 	
 	method asAnIfCondition() {
-		return if (@Expect(code = "shouldNotUseVoidMethodAsValue", message = "error") (pepita.ingest(10)))
+		return if (@Expect(code = "shouldNotUseVoidMethodAsValue", message = "error", expected="pepita.ingest(10)") (pepita.ingest(10)))
 			20
 		else 
 			30	
@@ -49,30 +49,30 @@ class MethodsCalledOnWellKnowObjects inherits A {
 	method asABinaryOperatorArgument() {
 		const cond = true
 		return [
-			10 + @Expect(code = "shouldNotUseVoidMethodAsValue", message = "error") (pepita.ingest(10)),
-			10 * @Expect(code = "shouldNotUseVoidMethodAsValue", message = "error") (pepita.ingest(10)),
-			cond && @Expect(code = "shouldNotUseVoidMethodAsValue", message = "error") (pepita.ingest(10)),
-			cond || @Expect(code = "shouldNotUseVoidMethodAsValue", message = "error") (pepita.ingest(10))
+			10 + @Expect(code = "shouldNotUseVoidMethodAsValue", message = "error", expected="pepita.ingest(10)") (pepita.ingest(10)),
+			10 * @Expect(code = "shouldNotUseVoidMethodAsValue", message = "error", expected="pepita.ingest(10)") (pepita.ingest(10)),
+			cond && @Expect(code = "shouldNotUseVoidMethodAsValue", message = "error", expected="pepita.ingest(10)") (pepita.ingest(10)),
+			cond || @Expect(code = "shouldNotUseVoidMethodAsValue", message = "error", expected="pepita.ingest(10)") (pepita.ingest(10))
 		]
 	}
 	
 	method asTargetForNewMessageSend() {
-		(@Expect(code = "shouldNotUseVoidMethodAsValue", message = "error") (pepita.ingest(10))).cantina() 
+		(@Expect(code = "shouldNotUseVoidMethodAsValue", message = "error", expected="pepita.ingest(10)") (pepita.ingest(10))).cantina() 
 	}
 	
 	method asListLiteralElement() {
-		return [1, 2, @Expect(code = "shouldNotUseVoidMethodAsValue", message = "error") (pepita.ingest(10))]
+		return [1, 2, @Expect(code = "shouldNotUseVoidMethodAsValue", message = "error", expected="pepita.ingest(10)") (pepita.ingest(10))]
 	}
 	
 	override method toBeOverriden(a) {
-		super(@Expect(code = "shouldNotUseVoidMethodAsValue", message = "error") (pepita.ingest(10)))
+		super(@Expect(code = "shouldNotUseVoidMethodAsValue", message = "error", expected="pepita.ingest(10)") (pepita.ingest(10)))
 	}
 	
 	method asConstructorArg() {
-		return new B(a = @Expect(code = "shouldNotUseVoidMethodAsValue", message = "error") (pepita.ingest(10)))
+		return new B(a = @Expect(code = "shouldNotUseVoidMethodAsValue", message = "error", expected="pepita.ingest(10)") (pepita.ingest(10)))
 	}
 	
-	method asExpressionOnMethodShortcut() = (@Expect(code = "shouldNotUseVoidMethodAsValue", message = "error") (pepita.ingest(10)))
+	method asExpressionOnMethodShortcut() = (@Expect(code = "shouldNotUseVoidMethodAsValue", message = "error", expected="pepita.ingest(10)") (pepita.ingest(10)))
 }
 
 class B {

--- a/test/validations/shouldOnlyInheritFromMixin.wlk
+++ b/test/validations/shouldOnlyInheritFromMixin.wlk
@@ -4,11 +4,8 @@ mixin MixinA {}
 
 mixin MixinB inherits MixinA {}
 
-@Expect(code="shouldOnlyInheritFromMixin", level="error", expectedOn="mixin BadMixin inherits SomeClass {}
-
-")
+@Expect(code="shouldOnlyInheritFromMixin", level="error", expectedOn="mixin BadMixin inherits SomeClass {}")
 mixin BadMixin inherits SomeClass {}
 
-@Expect(code="shouldOnlyInheritFromMixin", level="error", expectedOn="mixin AnotherBadMixin inherits MixinA and SomeClass {}
-")
+@Expect(code="shouldOnlyInheritFromMixin", level="error", expectedOn="mixin AnotherBadMixin inherits MixinA and SomeClass {}")
 mixin AnotherBadMixin inherits MixinA and SomeClass {}

--- a/test/validations/shouldOnlyInheritFromMixin.wlk
+++ b/test/validations/shouldOnlyInheritFromMixin.wlk
@@ -4,8 +4,11 @@ mixin MixinA {}
 
 mixin MixinB inherits MixinA {}
 
-@Expect(code="shouldOnlyInheritFromMixin", level="error")
+@Expect(code="shouldOnlyInheritFromMixin", level="error", expectedOn="mixin BadMixin inherits SomeClass {}
+
+")
 mixin BadMixin inherits SomeClass {}
 
-@Expect(code="shouldOnlyInheritFromMixin", level="error")
+@Expect(code="shouldOnlyInheritFromMixin", level="error", expectedOn="mixin AnotherBadMixin inherits MixinA and SomeClass {}
+")
 mixin AnotherBadMixin inherits MixinA and SomeClass {}

--- a/test/validations/shouldPassValuesToAllAttributes.wlk
+++ b/test/validations/shouldPassValuesToAllAttributes.wlk
@@ -33,19 +33,20 @@ class Entrenador {
 	var otraPepita = null
 	var torcaza = null
 	method crearUnAve() {
-		pepita = @Expect(code="shouldPassValuesToAllAttributes", level="error") new Ave(edad = 2) // missing 'energia'
+		pepita = @Expect(code="shouldPassValuesToAllAttributes", level="error", expectedOn="new Ave(edad = 2) // missing 'energia'") new Ave(edad = 2) // missing 'energia'
 		pepita = new Ave(edad = 2, energia = 50)
 		pepita = new Ave(energia = 50)
 	}
 	method crearOtraAve() {
-		otraPepita = @Expect(code="shouldPassValuesToAllAttributes", level="error") new Golondrina(edad = 2)
-		otraPepita = @Expect(code="shouldPassValuesToAllAttributes", level="error") new Golondrina(edad = 10, peso = 5) // missing 'energia'
+		otraPepita = @Expect(code="shouldPassValuesToAllAttributes", level="error", expectedOn="new Golondrina(edad = 2)
+		") new Golondrina(edad = 2)
+		otraPepita = @Expect(code="shouldPassValuesToAllAttributes", level="error", expectedOn="new Golondrina(edad = 10, peso = 5) // missing 'energia'") new Golondrina(edad = 10, peso = 5) // missing 'energia'
 		otraPepita = new Golondrina(edad = 10, peso = 5, energia = 56)
 	}
 	method crearTorcaza() {
 		torcaza = new Torcaza(color = "rojo", energia = 25, edad = 3) // OK
-		torcaza = @Expect(code="shouldPassValuesToAllAttributes", level="error") new Torcaza(color = "rojo") // missing 'energia'
-		torcaza = @Expect(code="shouldPassValuesToAllAttributes", level="error") new Torcaza(edad = 5) // missing 'color' and 'energia'
-		torcaza = @Expect(code="shouldPassValuesToAllAttributes", level="error") new Torcaza() // missing 'color' and 'energia'
+		torcaza = @Expect(code="shouldPassValuesToAllAttributes", level="error", expectedOn="new Torcaza(color = \"rojo\") // missing 'energia'") new Torcaza(color = "rojo") // missing 'energia'
+		torcaza = @Expect(code="shouldPassValuesToAllAttributes", level="error", expectedOn="new Torcaza(edad = 5) // missing 'color' and 'energia'") new Torcaza(edad = 5) // missing 'color' and 'energia'
+		torcaza = @Expect(code="shouldPassValuesToAllAttributes", level="error", expectedOn="new Torcaza() // missing 'color' and 'energia'") new Torcaza() // missing 'color' and 'energia'
 	}
 }

--- a/test/validations/shouldPassValuesToAllAttributes.wlk
+++ b/test/validations/shouldPassValuesToAllAttributes.wlk
@@ -38,8 +38,7 @@ class Entrenador {
 		pepita = new Ave(energia = 50)
 	}
 	method crearOtraAve() {
-		otraPepita = @Expect(code="shouldPassValuesToAllAttributes", level="error", expectedOn="new Golondrina(edad = 2)
-		") new Golondrina(edad = 2)
+		otraPepita = @Expect(code="shouldPassValuesToAllAttributes", level="error", expectedOn="new Golondrina(edad = 2)") new Golondrina(edad = 2)
 		otraPepita = @Expect(code="shouldPassValuesToAllAttributes", level="error", expectedOn="new Golondrina(edad = 10, peso = 5) // missing 'energia'") new Golondrina(edad = 10, peso = 5) // missing 'energia'
 		otraPepita = new Golondrina(edad = 10, peso = 5, energia = 56)
 	}

--- a/test/validations/shouldReturnAValueOnAllFlows.wlk
+++ b/test/validations/shouldReturnAValueOnAllFlows.wlk
@@ -17,7 +17,7 @@ object joaquin {
   }
 
   method testValorDevuelto() {
-    @Expect(code="shouldReturnAValueOnAllFlows", level="error")
+    @Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if (tocaEnGrupo) return 5")
     if (tocaEnGrupo) return 5
   }
 
@@ -148,32 +148,32 @@ object joaquin {
   // =====================================================================================
 
   method testValorDevueltoConMetodoGet() =
-    (@Expect(code="shouldReturnAValueOnAllFlows", level="error")
+    (@Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if (tocaEnGrupo) 5")
     if (tocaEnGrupo) 5)
 
   method validarFelicidad() {
-    assert.equals(10, @Expect(code="shouldReturnAValueOnAllFlows", level="error") if (tocaEnGrupo) 5)
+    assert.equals(10, @Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if (tocaEnGrupo) 5") if (tocaEnGrupo) 5)
   }
 
-  method felicidadTotal(numero) = numero + @Expect(code="shouldReturnAValueOnAllFlows", level="error") (if (tocaEnGrupo) 5)
+  method felicidadTotal(numero) = numero + @Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if (tocaEnGrupo) 5") (if (tocaEnGrupo) 5)
 
   method ifInsideExpressionWithoutElseShouldFailForReturn() {
-    return @Expect(code="shouldReturnAValueOnAllFlows", level="error") (if(1 == 2) 2)
+    return @Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if(1 == 2) 2") (if(1 == 2) 2)
   }
 
   method ifInsideExpressionWithoutElseShouldFailForBinaryLeftOperation() {
-    return (@Expect(code="shouldReturnAValueOnAllFlows", level="error") if(1 == 2) 2) + 3
+    return (@Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if(1 == 2) 2") if(1 == 2) 2) + 3
   }
 
   method ifInsideExpressionWithoutElseShouldFailInAssignment() {
-    var failed = @Expect(code="shouldReturnAValueOnAllFlows", level="error") if(1 == 2) 2
+    var failed = @Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if(1 == 2) 2") if(1 == 2) 2
     const ok = if (1 == 2) 2 else 3
     failed = ok
     return ok == 3
   }
 
   method invokeAddOneTo() {
-    return self.felicidadTotal(@Expect(code="shouldReturnAValueOnAllFlows", level="error") if (1 == 2) 4)
+    return self.felicidadTotal(@Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if (1 == 2) 4") if (1 == 2) 4)
   }
 
   method testValorDevueltoOFecha() =
@@ -186,15 +186,15 @@ object joaquin {
   }
 
   method alegria() {
-    return @Expect(code="shouldReturnAValueOnAllFlows", level="error") if (tocaEnGrupo) 22
+    return @Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if (tocaEnGrupo) 22") if (tocaEnGrupo) 22
   }
 
   method calcularNombre() {
-    return @Expect(code="shouldReturnAValueOnAllFlows", level="error") if (tocaEnGrupo) 22 else nombre = "Luis"
+    return @Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if (tocaEnGrupo) 22 else nombre = \"Luis\"") if (tocaEnGrupo) 22 else nombre = "Luis"
   }
 
   method definirNombre() {
-    return @Expect(code="shouldReturnAValueOnAllFlows", level="error") if (tocaEnGrupo) nombre = "Luis" else 22
+    return @Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if (tocaEnGrupo) nombre = \"Luis\" else 22") if (tocaEnGrupo) nombre = "Luis" else 22
   }
 
   // OK
@@ -242,13 +242,15 @@ class A {
   }
   
   method getZoo() { 
-    @Expect(code="shouldReturnAValueOnAllFlows", level="error")
+    @Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if (self.getFoo() == \"Foo\")  
+      return \"Foo\"")
     if (self.getFoo() == "Foo")  
       return "Foo"
   }
   
   method getZoo2() {
-    @Expect(code="shouldReturnAValueOnAllFlows", level="error")
+    @Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if (self.getFoo() == \"Foo\")
+      return \"Foo\"")
     if (self.getFoo() == "Foo")
       return "Foo"
     
@@ -257,7 +259,10 @@ class A {
   }
   
   method getXoo() { 
-    @Expect(code="shouldReturnAValueOnAllFlows", level="error")
+    @Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if (self.getFoo() == \"Foo\")  
+      return \"Foo\"
+    else
+      \"Bar\"")
     if (self.getFoo() == "Foo")  
       return "Foo"
     else
@@ -265,7 +270,13 @@ class A {
   }
   
   method getXoo2() {
-    @Expect(code="shouldReturnAValueOnAllFlows", level="error")
+    @Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if (self.getFoo() == \"Foo\") {
+      var a = 23
+      a += 2
+      return a
+    }
+    else
+      \"Bar\"")
     if (self.getFoo() == "Foo") {
       var a = 23
       a += 2
@@ -276,7 +287,13 @@ class A {
   }
   
   method getXoo3() {
-    @Expect(code="shouldReturnAValueOnAllFlows", level="error") 
+    @Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if (self.getFoo() == \"Foo\") {
+      \"Foo\"
+    }
+    else {
+      return \"Bar\"
+    }
+  ") 
     if (self.getFoo() == "Foo") {
       "Foo"
     }
@@ -394,8 +411,9 @@ object closureTests {
   }
 
   const property c2 = { 
-    @Expect(code="shouldReturnAValueOnAllFlows", level="error") 
-    if (bool) { return 1 } 
+    @Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if (bool) { return 1 }
+    ")
+    if (bool) { return 1 }
     bool = false
   }
 

--- a/test/validations/shouldReturnAValueOnAllFlows.wlk
+++ b/test/validations/shouldReturnAValueOnAllFlows.wlk
@@ -292,8 +292,7 @@ class A {
     }
     else {
       return \"Bar\"
-    }
-  ") 
+    }") 
     if (self.getFoo() == "Foo") {
       "Foo"
     }
@@ -411,8 +410,7 @@ object closureTests {
   }
 
   const property c2 = { 
-    @Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if (bool) { return 1 }
-    ")
+    @Expect(code="shouldReturnAValueOnAllFlows", level="error", expectedOn="if (bool) { return 1 }")
     if (bool) { return 1 }
     bool = false
   }

--- a/test/validations/shouldUseBooleanValueInIfCondition.wlk
+++ b/test/validations/shouldUseBooleanValueInIfCondition.wlk
@@ -7,39 +7,39 @@ object p {
 
     a = a + 1
     
-    @Expect(code="shouldUseBooleanValueInIfCondition", level="error")
+    @Expect(code="shouldUseBooleanValueInIfCondition", level="error", expectedOn="null")
     if (null)
       throw new Exception(message = "asd")
 
-    @Expect(code="shouldUseBooleanValueInIfCondition", level="error")
+    @Expect(code="shouldUseBooleanValueInIfCondition", level="error", expectedOn="2")
     if (2)
       throw new Exception(message = "asd")
         
-    @Expect(code="shouldUseBooleanValueInIfCondition", level="error")
+    @Expect(code="shouldUseBooleanValueInIfCondition", level="error", expectedOn="pepita")
     if (pepita)
       throw new Exception(message = "asd")
 
-    @Expect(code="shouldUseBooleanValueInIfCondition", level="error")
+    @Expect(code="shouldUseBooleanValueInIfCondition", level="error", expectedOn="new List()")
     if (new List())   
       throw new Exception(message = "asd")
     
-    @Expect(code="shouldUseBooleanValueInIfCondition", level="error")
+    @Expect(code="shouldUseBooleanValueInIfCondition", level="error", expectedOn="\"un poco de suerte\"")
     if ("un poco de suerte")   
       throw new Exception(message = "asd")
       
-    @Expect(code="shouldUseBooleanValueInIfCondition", level="error")
+    @Expect(code="shouldUseBooleanValueInIfCondition", level="error", expectedOn="[1, 2, 3]")
     if ([1, 2, 3])   
       throw new Exception(message = "asd")
     
-    @Expect(code="shouldUseBooleanValueInIfCondition", level="error")
+    @Expect(code="shouldUseBooleanValueInIfCondition", level="error", expectedOn="#{1, 2, 3}")
     if (#{1, 2, 3})   
       throw new Exception(message = "asd")  
     
-    @Expect(code="shouldUseBooleanValueInIfCondition", level="error")
+    @Expect(code="shouldUseBooleanValueInIfCondition", level="error", expectedOn="object {}")
     if (object {})   
       throw new Exception(message = "asd")
       
-    @Expect(code="shouldUseBooleanValueInIfCondition", level="error")
+    @Expect(code="shouldUseBooleanValueInIfCondition", level="error", expectedOn="{ a => a.toString() }")
     if ({ a => a.toString() })   
       throw new Exception(message = "asd")  
 

--- a/test/validations/shouldUseBooleanValueInLogicOperation.wlk
+++ b/test/validations/shouldUseBooleanValueInLogicOperation.wlk
@@ -4,19 +4,19 @@ object pepita {
 object p {
   method run() {        
     var cond = true
-    cond = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") !pepita
+    cond = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="!pepita") !pepita
 
-    cond = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") !new List()   
+    cond = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="!new List()") !new List()   
     
-    cond = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") not "un poco de suerte"
+    cond = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="not \"un poco de suerte\"") not "un poco de suerte"
       
-    cond = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") ! [1, 2, 3]
+    cond = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="! [1, 2, 3]") ! [1, 2, 3]
     
-    cond = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") ! #{1, 2, 3}
+    cond = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="! #{1, 2, 3}") ! #{1, 2, 3}
     
-    cond = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") ! object {}
+    cond = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="! object {}") ! object {}
       
-    cond = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") not { a => a.toString() }
+    cond = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="not { a => a.toString() }") not { a => a.toString() }
   }
 }
 
@@ -26,49 +26,49 @@ object q {
     
     // AND / &&  (left)
     
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") (null && value)
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="null && value") (null && value)
 
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") (2 && value)
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="2 && value") (2 && value)
 
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") (pepita && value)
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="pepita && value") (pepita && value)
 
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") (new List() && value)
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="new List() && value") (new List() && value)
     
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") ("un poco de suerte" && value)
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="\"un poco de suerte\" && value") ("un poco de suerte" && value)
       
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") ([1, 2, 3] && value)
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="[1, 2, 3] && value") ([1, 2, 3] && value)
     
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") (#{1, 2, 3} && value)
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="#{1, 2, 3} && value") (#{1, 2, 3} && value)
     
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") (object {} and value)
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="object {} and value") (object {} and value)
       
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") ({ a => a.toString() } && value)
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="{ a => a.toString() } && value") ({ a => a.toString() } && value)
 
     // AND / &&  (right)
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") (value and { a => a.toString() })
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="value and { a => a.toString() }") (value and { a => a.toString() })
 
     // OR / || (left)
     
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") (null || value)
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="null || value") (null || value)
 
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") (2 or value)
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="2 or value") (2 or value)
 
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") (pepita || value)
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="pepita || value") (pepita || value)
 
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") (new List() or value)
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="new List() or value") (new List() or value)
     
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") ("un poco de suerte" && value)
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="\"un poco de suerte\" && value") ("un poco de suerte" && value)
       
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") ([1, 2, 3] || value)
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="[1, 2, 3] || value") ([1, 2, 3] || value)
     
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") (#{1, 2, 3} or value)
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="#{1, 2, 3} or value") (#{1, 2, 3} or value)
     
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") (object {} || value)
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="object {} || value") (object {} || value)
       
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") ({ a => a.toString() } or value)
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="{ a => a.toString() } or value") ({ a => a.toString() } or value)
     
     // OR / || (right)
-    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error") (value || "un poco de suerte")
+    value = @Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="value || \"un poco de suerte\"") (value || "un poco de suerte")
 
   }
 }
@@ -76,37 +76,37 @@ object q {
 // Bad Conditions inside if
 object r {
   method run() {
-    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error") !null)
+    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="!null") !null)
       throw new Exception(message = "asd")
 
-    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error") not null)
+    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="not null") not null)
       throw new Exception(message = "asd")
 
-    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error") !2)
+    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="!2") !2)
       throw new Exception(message = "asd")
 
-    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error") not 2)
+    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="not 2") not 2)
       throw new Exception(message = "asd")
 
-    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error") !pepita)
+    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="!pepita") !pepita)
       throw new Exception(message = "asd")
 
-    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error") !new List())   
+    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="!new List()") !new List())
       throw new Exception(message = "asd")
     
-    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error") !"un poco de suerte")   
+    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="!\"un poco de suerte\"") !"un poco de suerte")
       throw new Exception(message = "asd")
       
-    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error") ![1, 2, 3])   
+    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="![1, 2, 3]") ![1, 2, 3])
       throw new Exception(message = "asd")
     
-    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error") !#{1, 2, 3})   
+    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="!#{1, 2, 3}") !#{1, 2, 3})
       throw new Exception(message = "asd")  
     
-    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error") !object {})   
+    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="!object {}") !object {})
       throw new Exception(message = "asd")
       
-    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error") !{ a => a.toString() })   
+    if (@Expect(code="shouldUseBooleanValueInLogicOperation", level="error", expectedOn="!{ a => a.toString() }") !{ a => a.toString() })   
       throw new Exception(message = "asd")  
 
   }

--- a/test/validations/shouldUseConditionalExpression.wlk
+++ b/test/validations/shouldUseConditionalExpression.wlk
@@ -1,7 +1,10 @@
 object sarasita {
   
   method withTheReturnWithinTheBranches(n) {
-    @Expect(code = "shouldUseConditionalExpression", level="warning")
+    @Expect(code = "shouldUseConditionalExpression", level="warning", expectedOn="if (n % 2 == 0)
+      return true
+    else
+      return false")
     if (n % 2 == 0)
       return true
     else
@@ -9,7 +12,11 @@ object sarasita {
   }
   
   method withBlockOnThenButSimpleExpressionOnElse(n) {
-    @Expect(code = "shouldUseConditionalExpression", level="warning")
+    @Expect(code = "shouldUseConditionalExpression", level="warning", expectedOn="if (n % 2 == 0) {
+      return true
+    }
+    else
+      return false")
     if (n % 2 == 0) {
       return true
     }
@@ -18,7 +25,11 @@ object sarasita {
   }
   
   method withSimpleExpressionNoBlockOnThen(n) {
-    @Expect(code = "shouldUseConditionalExpression", level="warning")
+    @Expect(code = "shouldUseConditionalExpression", level="warning", expectedOn="if (n % 2 == 0)
+      return true
+    else {
+      return false
+    }")
     if (n % 2 == 0)
       return true
     else {
@@ -27,14 +38,21 @@ object sarasita {
   }
   
   method withSimpleExpressionNoBlockReturnOutsideOfTheIf(n) {
-    return @Expect(code = "shouldUseConditionalExpression", level="warning") if (n % 2 == 0)
+    return @Expect(code = "shouldUseConditionalExpression", level="warning", expectedOn="if (n % 2 == 0)
+      true
+    else
+      false") if (n % 2 == 0)
       true
     else
       false
   }
   
   method esPar5(n) {
-    return @Expect(code = "shouldUseConditionalExpression", level="warning") if (n % 2 == 0) {
+    return @Expect(code = "shouldUseConditionalExpression", level="warning", expectedOn="if (n % 2 == 0) {
+      true
+    }
+    else
+      false") if (n % 2 == 0) {
       true
     }
     else
@@ -42,7 +60,11 @@ object sarasita {
   }
 
   method invertedCondition(n) {
-    return @Expect(code = "shouldUseConditionalExpression", level="warning") (if (n % 2 == 0) {
+    return @Expect(code = "shouldUseConditionalExpression", level="warning", expectedOn="if (n % 2 == 0) {
+      false
+    }
+    else
+      true") (if (n % 2 == 0) {
       false
     }
     else
@@ -50,7 +72,11 @@ object sarasita {
   }
   
   method invertedConditionWithReturnWithinBranches(n) {
-    @Expect(code = "shouldUseConditionalExpression", level="warning")
+    @Expect(code = "shouldUseConditionalExpression", level="warning", expectedOn="if (n % 2 == 0) {
+      return false
+    }
+    else
+      return true")
     if (n % 2 == 0) {
       return false
     }
@@ -59,11 +85,13 @@ object sarasita {
   }
   
   method invertedWithSimpleExpressionNoBlock(n) {
-    return @Expect(code = "shouldUseConditionalExpression", level="warning") if (n % 2 == 0) false else true
+    return @Expect(code = "shouldUseConditionalExpression", level="warning", expectedOn="if (n % 2 == 0) false else true") if (n % 2 == 0) false else true
   }
 
   method esPar6(n) {
-    @Expect(code = "shouldUseConditionalExpression", level="warning")
+    @Expect(code = "shouldUseConditionalExpression", level="warning", expectedOn="if (n % 2 == 0) {
+      return true
+    }")
     if (n % 2 == 0) {
       return true
     }
@@ -71,7 +99,9 @@ object sarasita {
   }
 
   method esPar7(n) {
-    @Expect(code = "shouldUseConditionalExpression", level="warning")
+    @Expect(code = "shouldUseConditionalExpression", level="warning", expectedOn="if (n % 2 == 0) {
+      return false
+    }")
     if (n % 2 == 0) {
       return false
     }

--- a/test/validations/shouldUseSelfAndNotSingletonReference.wlk
+++ b/test/validations/shouldUseSelfAndNotSingletonReference.wlk
@@ -1,6 +1,6 @@
 object pepita {
   var energy = 100
-  var property friend = @Expect(code="shouldUseSelfAndNotSingletonReference", level="warning") (pepita)
+  var property friend = @Expect(code="shouldUseSelfAndNotSingletonReference", level="warning", expectedOn="pepita") (pepita)
 
   method fly(kilometers) {
     energy = energy - (kilometers * 2)
@@ -11,13 +11,13 @@ object pepita {
   }
 
   method enjoy() {
-    @Expect(code="shouldUseSelfAndNotSingletonReference", level="warning") 
+    @Expect(code="shouldUseSelfAndNotSingletonReference", level="warning", expectedOn="pepita")
     pepita.eat(5)
 
-    @Expect(code="shouldUseSelfAndNotSingletonReference", level="warning") (pepita)
+    @Expect(code="shouldUseSelfAndNotSingletonReference", level="warning", expectedOn="pepita") (pepita)
 
     self.eat(1)
 
-    self.friend(@Expect(code="shouldUseSelfAndNotSingletonReference", level="warning") pepita)
+    self.friend(@Expect(code="shouldUseSelfAndNotSingletonReference", level="warning", expectedOn="pepita") pepita)
   }
 }

--- a/test/validations/shouldUseSuperOnlyOnOverridingMethod.wlk
+++ b/test/validations/shouldUseSuperOnlyOnOverridingMethod.wlk
@@ -12,7 +12,7 @@ class Golondrina {
 
 class GolondrinaRenga inherits Golondrina {
   override method jugar() {
-    @Expect(code="shouldUseSuperOnlyOnOverridingMethod", level="error", expectedOn="super(1)\n  ")
+    @Expect(code="shouldUseSuperOnlyOnOverridingMethod", level="error", expectedOn="super(1)")
     super(1)
   }
 }

--- a/test/validations/shouldUseSuperOnlyOnOverridingMethod.wlk
+++ b/test/validations/shouldUseSuperOnlyOnOverridingMethod.wlk
@@ -12,7 +12,7 @@ class Golondrina {
 
 class GolondrinaRenga inherits Golondrina {
   override method jugar() {
-    @Expect(code="shouldUseSuperOnlyOnOverridingMethod", level="error")
+    @Expect(code="shouldUseSuperOnlyOnOverridingMethod", level="error", expectedOn="super(1)\n  ")
     super(1)
   }
 }

--- a/test/validations/topLevelSingletonShouldHaveAName.wlk
+++ b/test/validations/topLevelSingletonShouldHaveAName.wlk
@@ -4,5 +4,5 @@ object namedObject {
 }
 
 // Top level objects can't be unnamed
-@Expect(code="topLevelSingletonShouldHaveAName", level="error")
+@Expect(code="topLevelSingletonShouldHaveAName", level="error", expectedOn="object { }")
 object { }


### PR DESCRIPTION
Ahora los tests del validador aceptan dentro de la anotación `Expected` el atributo `expectedOn` para circunscribir dónde debería marcarse el error. Ejemplo:

```wollok
@Expect(code="nameShouldBeginWithLowercase", level="warning", expectedOn="SomeObject")
object SomeObject {}
```

