### PR TITLE
Update exception handler for game

### DIFF
--- a/src/wollok/game.wlk
+++ b/src/wollok/game.wlk
@@ -5,8 +5,16 @@ import wollok.vm.runtime
   */
 object game {
 
+  /** Collection of visual objects in the game */
   const visuals = []
+  /** Game is running? */
   var property running = false
+  /**
+   * Allows to configure a visual component as "error reporter".
+   * Then every error in game board will be reported by this visual component,
+   * in a balloon message form.
+   */
+  var property errorReporter = null
 
   override method initialize() {
     super()
@@ -213,7 +221,9 @@ object game {
   method start() {
     self.running(true)
     io.exceptionHandler({ exception => exception.printStackTrace() })
-    io.domainExceptionHandler({exception => self.say(exception.source(), exception.message())})
+    io.domainExceptionHandler({ exception => 
+      const reporter = if (errorReporter == null) exception.source() else errorReporter
+      self.say(reporter, exception.message())})
   }
   
   /**
@@ -298,14 +308,7 @@ object game {
    * Default behavior is to show them, so this is not necessary.
    */
   method showAttributes(visual) native
-  
-  /**
-   * Allows to configure a visual component as "error reporter".
-   * Then every error in game board will be reported by this visual component,
-   * in a balloon message form.
-   */
-  method errorReporter(visual) native
-     
+       
   /**
    * Returns a sound object. Audio file must be a .mp3, .ogg or .wav file.
    */ 

--- a/src/wollok/game.wlk
+++ b/src/wollok/game.wlk
@@ -7,7 +7,7 @@ object game {
 
   /** Collection of visual objects in the game */
   const visuals = []
-  /** Game is running? */
+  /** Is Game running? */
   var property running = false
   /**
    * Allows to configure a visual component as "error reporter".

--- a/src/wollok/game.wlk
+++ b/src/wollok/game.wlk
@@ -212,7 +212,7 @@ object game {
    */  
   method start() {
     self.running(true)
-    io.exceptionHandler({ exception => console.println(exception)})
+    io.exceptionHandler({ exception => exception.printStackTrace() })
     io.domainExceptionHandler({exception => self.say(exception.source(), exception.message())})
   }
   

--- a/test/game/actions.wpgm
+++ b/test/game/actions.wpgm
@@ -4,6 +4,10 @@ object visual {
   method position() = game.origin()
 }
 
+object reporter {
+  method position() = game.origin()
+}
+
 program say {
   game.addVisual(visual)
   game.start()
@@ -12,16 +16,23 @@ program say {
 
 program domainError {
   game.addVisual(visual)
-  const tick = new Tick(interval = 1, action = { visual.error("DOMAIN_ERROR") })
+  new Tick(interval = 1, action = { visual.error("DOMAIN_ERROR") }).start()
   game.start()
-  tick.start()
+  game.flushEvents(1)
+}
+
+program domainErrorWithReporter {
+  game.addVisual(visual)
+  game.addVisual(reporter)
+  game.errorReporter(reporter)
+  new Tick(interval = 1, action = { visual.error("DOMAIN_ERROR") }).start()
+  game.start()
   game.flushEvents(1)
 }
 
 program genericError {
   game.addVisual(visual)
-  const tick = new Tick(interval = 1, action = { throw new Exception(message = "ERROR") })
+  new Tick(interval = 1, action = { throw new Exception(message = "ERROR") }).start()
   game.start()
-  tick.start()
   game.flushEvents(1)
 }

--- a/test/game/actions.wpgm
+++ b/test/game/actions.wpgm
@@ -4,21 +4,24 @@ object visual {
   method position() = game.origin()
 }
 
-program addVisual {
-  game.addVisual(visual)
-}
-
-program removeVisual {
-  game.addVisual(visual)
-  game.removeVisual(visual)
-}
-
 program say {
   game.addVisual(visual)
+  game.start()
   game.say(visual, "Hi!")
 }
 
-program clear {
+program domainError {
   game.addVisual(visual)
-  game.clear()
+  const tick = new Tick(interval = 1, action = { visual.error("DOMAIN_ERROR") })
+  game.start()
+  tick.start()
+  game.flushEvents(1)
+}
+
+program genericError {
+  game.addVisual(visual)
+  const tick = new Tick(interval = 1, action = { throw new Exception(message = "ERROR") })
+  game.start()
+  tick.start()
+  game.flushEvents(1)
 }

--- a/test/sanity/game/game.wtest
+++ b/test/sanity/game/game.wtest
@@ -117,6 +117,12 @@ describe "Game" {
     assert.equals([myVisual, visual2, visual3].asSet(), game.allVisuals().asSet())
   }
 
+  test "clear remove all visuals" {
+    game.addVisual(myVisual)
+    game.clear()
+  	assert.that(game.allVisuals().isEmpty())
+  }
+
   test "cell size fails when set to 0" {
     assert.throwsException { => game.cellSize(0) }
   }
@@ -160,7 +166,7 @@ describe "Game" {
     game.addVisualCharacter(character)
     // Simulate
     io.queueEvent(["keypress", "ArrowUp"])
-    io.flushEvents(0)
+    game.flushEvents(0)
     
     assert.equals(game.at(0, 1), character.position())
   }

--- a/test/sanity/game/game.wtest
+++ b/test/sanity/game/game.wtest
@@ -120,7 +120,7 @@ describe "Game" {
   test "clear remove all visuals" {
     game.addVisual(myVisual)
     game.clear()
-  	assert.that(game.allVisuals().isEmpty())
+    assert.that(game.allVisuals().isEmpty())
   }
 
   test "cell size fails when set to 0" {


### PR DESCRIPTION
Ahora cuando hay una excepción que no es de dominio dentro de un juego printea todo el stack trace en vez de solo `an Exception`.

También agregué soporte para el `errorReporter` que se estaba ignorando 👀 

#### Mirar tests en https://github.com/uqbar-project/wollok-ts/pull/244