### PR TITLE
#197 b option center position reference to a mutable and a collection of centers to update when game starts.

### DIFF
--- a/src/wollok/game.wlk
+++ b/src/wollok/game.wlk
@@ -4,7 +4,7 @@ import wollok.vm.runtime
   * Wollok Game main object 
   */
 object game {
-
+  const center = new MutablePosition(x = self.xCenter(), y = self.yCenter())
   /** Collection of visual objects in the game */
   const visuals = []
   /** Is Game running? */
@@ -219,6 +219,7 @@ object game {
    * Starts render the board in a new windows.
    */  
   method start() {
+    self.updateCenter()
     self.running(true)
     io.exceptionHandler({ exception => exception.printStackTrace() })
     io.domainExceptionHandler({ exception => 
@@ -241,7 +242,30 @@ object game {
   /**
    * Returns the center board position (rounded down).
    */  
-  method center() = self.at(self.width().div(2), self.height().div(2))
+  method center() = center
+
+  //Subtask to use on Start.
+  method updateCenter(){
+    self.updateCenterX()
+    self.updateCenterY()
+  }
+
+  method updateCenterX(){
+    center.x(self.xCenter())
+  }
+
+  method updateCenterY(){
+    center.y(self.yCenter())
+  }
+
+  //To not duplicate in default and after defeault.
+  method xCenter() = self.midRoundDown(self.width())
+
+  //To not duplicate in default and after defeault.
+  method yCenter() = self.midRoundDown(self.height())
+ 
+  //To not duplicate div(2) on xCenter and yCenter. Can be remove and duplicated.
+  method midRoundDown(n) = n.div(2)
 
   /**
    * Sets game title.


### PR DESCRIPTION
Use a "strategy" (is more like a state mixed) to collect every Center Mutable Positions (at 0,0) requiered before game starts. Then update each of them by the current Board Size to respect the go up, go down, go left, go right before start. The change to a simpler center with the "original" logic but in delegated to another "strategy". Could be a state but require a setter for var center in game. Use 0,0 to simplify offset and prevent issues like resize of the board not be rounded down or not in x or y.