### PR TITLE
Map and flatMap without return value now throws a better error

### DIFF
--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -227,6 +227,9 @@ class Object {
 
   /** @private */
   method checkNotNull(value, message) native
+
+  /** @private */
+  method checkNotVoid(value, message) native
 }
 
 /** Representation for methods that only have side effects */
@@ -682,9 +685,10 @@ class Collection {
   @Type(variable="Mapped", name="List<Mapped>")
   method map(@Type(name="{ (Element) => Mapped }") closure) {
     self.checkNotNull(closure, "map")
-    return self.fold([], { newCollection, element =>
-      newCollection.add(closure.apply(element))
-      newCollection
+    return self.fold([], { newCollection, element => 
+        self.checkNotVoid(closure.apply(element), "Message send \"closure.apply(element)\" produces no value (missing return in method?)")
+        newCollection.add(closure.apply(element))
+        return newCollection
     })
   }
 
@@ -710,8 +714,9 @@ class Collection {
   method flatMap(closure) {
     self.checkNotNull(closure, "flatMap")
     return self.fold(self.newInstance(), { flattenedList, element =>
+      self.checkNotVoid(closure.apply(element), "Message send \"closure.apply(element)\" produces no value (missing return in method?)")
       flattenedList.addAll(closure.apply(element))
-      flattenedList
+      return flattenedList
     })
   }
 
@@ -2563,7 +2568,10 @@ class Range {
   method map(closure) {
     self.checkNotNull(closure, "map")
     const list = []
-    self.forEach { element => list.add(closure.apply(element)) }
+    self.forEach { element => 
+      self.checkNotVoid(closure.apply(element), "Message send \"closure.apply(element)\" produces no value (missing return in method?)")
+      list.add(closure.apply(element)) 
+    }
     return list
   }
 
@@ -2578,8 +2586,9 @@ class Range {
   method flatMap(closure) {
     self.checkNotNull(closure, "flatMap")
     return self.fold([], { seed, element =>
+      self.checkNotVoid(closure.apply(element), "Message send \"closure.apply(element)\" produces no value (missing return in method?)")
       seed.addAll(closure.apply(element))
-      seed
+      return seed 
     })
   }
 

--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -2585,6 +2585,7 @@ class Range {
     return self.fold([], { seed, element =>
       seed.addAll(closure.apply(element))
       seed
+    })
   }
 
   /** @private */

--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -212,6 +212,10 @@ class Object {
     throw new MessageNotUnderstoodException(message = aMessage)
   }
 
+  method generateEvaluationError(message) {
+    throw new EvaluationError(message = message)
+  }
+
   /**
    * @private
    *
@@ -227,9 +231,6 @@ class Object {
 
   /** @private */
   method checkNotNull(value, message) native
-
-  /** @private */
-  method checkNotVoid(value, message) native
 }
 
 /** Representation for methods that only have side effects */
@@ -685,8 +686,7 @@ class Collection {
   @Type(variable="Mapped", name="List<Mapped>")
   method map(@Type(name="{ (Element) => Mapped }") closure) {
     self.checkNotNull(closure, "map")
-    return self.fold([], { newCollection, element => 
-        self.checkNotVoid(closure.apply(element), "Message send \"closure.apply(element)\" produces no value (missing return in method?)")
+    return self.fold([], { newCollection, element =>
         newCollection.add(closure.apply(element))
         return newCollection
     })
@@ -714,7 +714,6 @@ class Collection {
   method flatMap(closure) {
     self.checkNotNull(closure, "flatMap")
     return self.fold(self.newInstance(), { flattenedList, element =>
-      self.checkNotVoid(closure.apply(element), "Message send \"closure.apply(element)\" produces no value (missing return in method?)")
       flattenedList.addAll(closure.apply(element))
       return flattenedList
     })

--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -2568,10 +2568,7 @@ class Range {
   method map(closure) {
     self.checkNotNull(closure, "map")
     const list = []
-    self.forEach { element => 
-      self.checkNotVoid(closure.apply(element), "Message send \"closure.apply(element)\" produces no value (missing return in method?)")
-      list.add(closure.apply(element)) 
-    }
+    self.forEach { element => list.add(closure.apply(element)) }
     return list
   }
 
@@ -2586,10 +2583,8 @@ class Range {
   method flatMap(closure) {
     self.checkNotNull(closure, "flatMap")
     return self.fold([], { seed, element =>
-      self.checkNotVoid(closure.apply(element), "Message send \"closure.apply(element)\" produces no value (missing return in method?)")
       seed.addAll(closure.apply(element))
-      return seed 
-    })
+      seed
   }
 
   /** @private */

--- a/test/sanity/collections/collections.wtest
+++ b/test/sanity/collections/collections.wtest
@@ -159,6 +159,14 @@ describe "Collection test case" {
     const evens = #{1,2,3}.map({n => n.even()})
     assert.equals([false, true, false], evens)
   }
+
+  test "map closure with void return type" {
+    assert.throwsExceptionWithMessage("Message send \"closure.apply(element)\" produces no value (missing return in method?)", { #{1,2,3}.map({n => [].add(n)}) })
+  }
+
+  test "flatMap closure with void return type" {
+    assert.throwsExceptionWithMessage("Message send \"closure.apply(element)\" produces no value (missing return in method?)", { [[1, 2, 3], [4, 5, 6]].flatMap({ list => [].addAll(list) }) })
+  }
     
   test "shortcut avoiding parenthesis" {
     const greaterThanFiveElements = numbers.filter { n => n > 5 }


### PR DESCRIPTION
Add check if closure.apply(element) return voids and if so throws a better message than before.

Before:
```
  wollok.lang.EvaluationError wrapping TypeScript Error: Could not resolve reference to element or its a reference to void
```

Now:
```
  wollok.lang.DomainException: Message send "closure.apply(element)" produces no value (missing return in method?)
```

<img width="890" alt="image" src="https://github.com/user-attachments/assets/208768eb-8737-4bf1-9656-0b35ef06fcec">

Nos esta rompiendo un test de un example, hay que revisar si esta bien como hicimos el checkeo de void