### PR TITLE
Mejoras al manejo de void (y algo de nulls), especialmente para bloques

### DIFF
--- a/src/resources/validationMessages/en.json
+++ b/src/resources/validationMessages/en.json
@@ -48,6 +48,7 @@
   "shouldNotUseOverride": "Method does not override anything",
   "shouldNotUseReservedWords": "{0} is a reserved name for a core element",
   "shouldNotUseVoidMethodAsValue": "Message send \"{0}\" produces no value (missing return in method?)",
+  "shouldNotUseVoidSingleton": "Named object 'void' produces no value, use 'null' instead",
   "shouldOnlyInheritFromMixin": "Mixin can only inherit from another mixin",
   "shouldPassValuesToAllAttributes": "{0} cannot be instantiated, you must pass values to the following attributes: {1}",
   "shouldUseBooleanValueInIfCondition": "Expecting a boolean",

--- a/src/resources/validationMessages/es.json
+++ b/src/resources/validationMessages/es.json
@@ -48,6 +48,7 @@
   "shouldNotUseOverride": "Este método no sobrescribe ningún otro método",
   "shouldNotUseReservedWords": "{0} es una palabra reservada por la biblioteca de Wollok",
   "shouldNotUseVoidMethodAsValue": "El mensaje \"{0}\" no retorna ningún valor (quizás te falte un return en el método)",
+  "shouldNotUseVoidSingleton": "El objeto nombrado 'void' no retorna ningún valor (puede usar 'null' en su lugar)",
   "shouldOnlyInheritFromMixin": "Los mixines solo pueden heredar de otros mixines",
   "shouldPassValuesToAllAttributes": "No se puede instanciar {0}. Falta pasar valores a los siguientes atributos: {1}",
   "shouldUseBooleanValueInIfCondition": "Se espera un booleano",

--- a/src/wollok/game.wlk
+++ b/src/wollok/game.wlk
@@ -24,7 +24,7 @@ object game {
     self.height(5)
     self.cellSize(50)
     self.ground("ground.png")
-    }
+  }
   
   /**
    * Adds an object to the board for drawing it.
@@ -99,9 +99,9 @@ object game {
    *     game.whenCollideDo(pepita, { comida => pepita.comer(comida) })
    */  
     method whenCollideDo(visual, action) {
-    io.addCollitionHandler(visual.identity(), {  => 
-			self.colliders(visual).forEach({it => action.apply(it)})
-		})
+      io.addCollitionHandler(visual.identity(), {  => 
+        self.colliders(visual).forEach({it => action.apply(it)})
+      })
   }
 
   /**

--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -265,6 +265,21 @@ class Pair {
  */
 @Type(variable="Element")
 class Collection {
+
+  /**
+   * Checks that a closure returns a valid value.
+   * It's a basic validation for closures with one parameter.
+   *
+   * Example:
+   *       [1, 2].checkValidClosure({ n => n + 1})      // ok
+   *       [1, 2].checkValidClosure({ => 2 })           // error, closure expects 1 parameter
+   *       [1, 2].checkValidClosure({ a, b => a + b })  // error, closure expects 1 parameter
+   *       [1, 2].checkValidClosure({ n => [].add(n) }) // error, closure does not return a value (it's void)
+   *
+   * @throws an error if closure is void
+   */
+  method checkValidClosure(closure, message)
+
   /**
    * Answers the element that is considered to be/have the maximum value.
    * The criteria is given by a closure that receives a single element
@@ -281,6 +296,7 @@ class Collection {
    */
   method max(closure) {
     self.checkNotNull(closure, "max")
+    self.checkValidClosure(closure, "max")
     return self.maxIfEmpty(closure, { throw new ElementNotFoundException(message = "collection is empty") })
   }
 
@@ -313,6 +329,7 @@ class Collection {
    */
   method maxIfEmpty(toComparableClosure, emptyCaseClosure) {
     self.checkNotNull(toComparableClosure, "maxIfEmpty")
+    self.checkValidClosure(toComparableClosure, "maxIfEmpty")
     self.checkNotNull(emptyCaseClosure, "maxIfEmpty")
     return self.absolute(toComparableClosure, { a, b => a > b }, emptyCaseClosure)
   }
@@ -345,6 +362,7 @@ class Collection {
    */
   method min(closure) {
     self.checkNotNull(closure, "min")
+    self.checkValidClosure(closure, "min")
     return self.absolute(closure, { a, b => a < b }, { throw new ElementNotFoundException(message = "collection is empty") })
   }
 
@@ -377,6 +395,7 @@ class Collection {
    */
   method minIfEmpty(toComparableClosure, emptyCaseClosure) {
     self.checkNotNull(toComparableClosure, "minIfEmpty")
+    self.checkValidClosure(toComparableClosure, "sum")
     self.checkNotNull(emptyCaseClosure, "minIfEmpty")
     return self.absolute(toComparableClosure, { a, b => a < b }, emptyCaseClosure)
   }
@@ -542,6 +561,7 @@ class Collection {
    */
   method all(predicate) {
     self.checkNotNull(predicate, "all")
+    self.checkValidClosure(predicate, "all")
     return self.fold(true, { seed, element => if (!seed) seed else predicate.apply(element) })
   }
 
@@ -558,6 +578,7 @@ class Collection {
    */
   method any(predicate) {
     self.checkNotNull(predicate, "any")
+    self.checkValidClosure(predicate, "any")
     return self.fold(false, { seed, element => if (seed) seed else predicate.apply(element) })
   }
 
@@ -577,6 +598,7 @@ class Collection {
    */
   method find(predicate) {
     self.checkNotNull(predicate, "find")
+    self.checkValidClosure(predicate, "find")
     return self.findOrElse(predicate, {
       throw new ElementNotFoundException(message = "there is no element that satisfies the predicate")
     })
@@ -626,6 +648,7 @@ class Collection {
    */
   method count(predicate) {
     self.checkNotNull(predicate, "count")
+    self.checkValidClosure(predicate, "count")
     return self.fold(0, { total, element => if (predicate.apply(element)) total+1 else total  })
   }
 
@@ -654,6 +677,7 @@ class Collection {
    */
   method sum(closure) {
     self.checkNotNull(closure, "sum")
+    self.checkValidClosure(closure, "sum")
     return self.fold(0, { total, element => total + closure.apply(element) })
   }
 
@@ -666,7 +690,7 @@ class Collection {
    *      [].sum()               => Answers 0
    */
   method sum() = self.sum( {it => it} )
-
+  
   /**
    * Answers a new collection that contains the result of transforming
    * each of self collection's elements using a given closure.
@@ -682,6 +706,7 @@ class Collection {
   @Type(variable="Mapped", name="List<Mapped>")
   method map(@Type(name="{ (Element) => Mapped }") closure) {
     self.checkNotNull(closure, "map")
+    self.checkValidClosure(closure, "map")
     return self.fold([], { newCollection, element =>
       newCollection.add(closure.apply(element))
       newCollection
@@ -709,6 +734,7 @@ class Collection {
    */
   method flatMap(closure) {
     self.checkNotNull(closure, "flatMap")
+    self.checkValidClosure(closure, "flatMap")
     return self.fold(self.newInstance(), { flattenedList, element =>
       flattenedList.addAll(closure.apply(element))
       flattenedList
@@ -729,9 +755,10 @@ class Collection {
    */
   method filter(closure) {
     self.checkNotNull(closure, "filter")
-     return self.fold(self.newInstance(), { newCollection, element =>
+    self.checkValidClosure(closure, "filter")
+    return self.fold(self.newInstance(), { newCollection, element =>
       if (closure.apply(element))
-         newCollection.add(element)
+        newCollection.add(element)
       newCollection
     })
   }
@@ -969,6 +996,20 @@ class Set inherits Collection {
   override method toStringSuffix() = "}"
 
   /**
+   * Checks that a closure returns a valid value.
+   * It's a basic validation for closures with one parameter.
+   *
+   * Example:
+   *       [1, 2].checkValidClosure({ n => n + 1})      // ok
+   *       [1, 2].checkValidClosure({ => 2 })           // error, closure expects 1 parameter
+   *       [1, 2].checkValidClosure({ a, b => a + b })  // error, closure expects 1 parameter
+   *       [1, 2].checkValidClosure({ n => [].add(n) }) // error, closure does not return a value (it's void)
+   *
+   * @throws an error if closure is void
+   */
+  override method checkValidClosure(closure, message) native
+
+  /**
    * Converts this set to a list.
    *
    * Examples
@@ -1198,6 +1239,20 @@ class Set inherits Collection {
  */
 @Type(variable="Element")
 class List inherits Collection {
+
+  /**
+   * Checks that a closure returns a valid value.
+   * It's a basic validation for closures with one parameter.
+   *
+   * Example:
+   *       [1, 2].checkValidClosure({ n => n + 1})      // ok
+   *       [1, 2].checkValidClosure({ => 2 })           // error, closure expects 1 parameter
+   *       [1, 2].checkValidClosure({ a, b => a + b })  // error, closure expects 1 parameter
+   *       [1, 2].checkValidClosure({ n => [].add(n) }) // error, closure does not return a value (it's void)
+   *
+   * @throws an error if closure is void
+   */
+  override method checkValidClosure(closure, message) native
 
   /**
    * Answers the element at the specified position in this non-empty list.
@@ -2569,12 +2624,7 @@ class Range {
    * Example:
    *      (1..10).map({ n => n * 2}) ==> Answers [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
    */
-  method map(closure) {
-    self.checkNotNull(closure, "map")
-    const list = []
-    self.forEach { element => list.add(closure.apply(element)) }
-    return list
-  }
+  method map(closure) = self.asList().map(closure)
 
   /**
    * Map + flatten operation
@@ -2584,17 +2634,13 @@ class Range {
    * Example:
    *      (1..4).flatMap({ n => 1 .. n }) ==> Answers [1, 1, 2, 1, 2, 3, 1, 2, 3, 4]
    */
-  method flatMap(closure) {
-    self.checkNotNull(closure, "flatMap")
-    return self.fold([], { seed, element =>
-      seed.addAll(closure.apply(element))
-      seed
-    })
-  }
+  method flatMap(closure) = self.asList().flatMap(closure)
 
   /** @private */
   method asList() {
-    return self.map({ elem => elem })
+    const list = []
+    self.forEach { element => list.add(element) }
+    return list
   }
 
   /**

--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -546,14 +546,10 @@ class Collection {
     return self.fold(true, { seed, element => 
       if (!seed) 
         seed
-      else {
-        const satisfies = predicate.apply(element)
-        if (satisfies === void) {
-          throw new Exception(message = "Message all: predicate produces no value. Check the return type of the closure.")
-        }
-        satisfies
+      else 
+        predicate.apply(element)
       }
-    })
+    )
   }
 
   /**
@@ -572,14 +568,10 @@ class Collection {
     return self.fold(false, { seed, element => 
       if (seed)
         seed
-      else {
-        const satisfies = predicate.apply(element)
-        if (satisfies === void) {
-          throw new Exception(message = "Message any: predicate produces no value. Check the return type of the closure.")
-        }
-        satisfies
+      else 
+        predicate.apply(element)
       }
-    })
+    )
   }
 
   /**
@@ -648,11 +640,7 @@ class Collection {
   method count(predicate) {
     self.checkNotNull(predicate, "count")
     return self.fold(0, { total, element =>
-      const satisfies = predicate.apply(element)
-      if (satisfies === void) {
-        throw new Exception(message = "Message count: predicate produces no value. Check the return type of the closure.")
-      }
-      if (satisfies) total+1 else total
+      if (predicate.apply(element)) total+1 else total
     })
   }
 
@@ -682,11 +670,7 @@ class Collection {
   method sum(closure) {
     self.checkNotNull(closure, "sum")
     return self.fold(0, { total, element => 
-      const amount = closure.apply(element)
-      if (amount === void) {
-        throw new Exception(message = "Message sum: closure produces no value. Check the return type of the closure.")
-      }
-      total + amount
+      total + closure.apply(element)
     })
   }
 
@@ -716,11 +700,7 @@ class Collection {
   method map(@Type(name="{ (Element) => Mapped }") closure) {
     self.checkNotNull(closure, "map")
     return self.fold([], { newCollection, element =>
-      const value = closure.apply(element)
-      if (value === void) {
-        throw new Exception(message = "Message map: closure produces no value. Check the return type of the closure.")
-      }
-      newCollection.add(value)
+      newCollection.add(closure.apply(element))
       newCollection
     })
   }
@@ -747,10 +727,6 @@ class Collection {
   method flatMap(closure) {
     self.checkNotNull(closure, "flatMap")
     return self.fold(self.newInstance(), { flattenedList, element =>
-      const value = closure.apply(element)
-      if (value === void) {
-        throw new Exception(message = "Message flatMap: closure produces no value. Check the return type of the closure.")
-      }
       flattenedList.addAll(closure.apply(element))
       flattenedList
     })
@@ -771,11 +747,7 @@ class Collection {
   method filter(closure) {
     self.checkNotNull(closure, "filter")
     return self.fold(self.newInstance(), { newCollection, element =>
-      const satisfies = closure.apply(element)
-      if (satisfies === void) {
-        throw new Exception(message = "Message filter: closure produces no value. Check the return type of the closure.")
-      }
-      if (satisfies) {
+      if (closure.apply(element)) {
         newCollection.add(element)
       }
       newCollection

--- a/test/sanity/basics/ranges/ranges.wtest
+++ b/test/sanity/basics/ranges/ranges.wtest
@@ -38,6 +38,16 @@ describe "ranges" {
     assert.equals(90, range.sum({ n => n * 2 }))
   }
 
+  test "sum using void closure should fail" {
+    const range = 0 .. 9
+    assert.throwsException { range.sum({ [1].add(2) }) }
+  }
+
+  test "sum using null should fail" {
+    const range = 0 .. 9
+    assert.throwsException { range.sum(null) }
+  }
+
   test "contains" {
     const range = 0 .. 9 
     assert.that(range.contains(9))
@@ -71,10 +81,27 @@ describe "ranges" {
     assert.notThat((0..10).any({ elem => elem == 15}))
   }
 
+  test "any using null should fail" {
+    assert.throwsException { => (1..3).any(null) }
+  }
+
+  test "any using void closure should fail" {
+    assert.throwsException { => (1..3).any { [1, 2].add(3) } }
+  }
+
+
   test "all" {
     const range = 0 .. 10 
     assert.notThat(range.all({ elem => elem.even()}))
     assert.that(range.any({ elem => elem < 11}))
+  }
+
+  test "all using null should fail" {
+    assert.throwsException { => (1..3).all(null) }
+  }
+
+  test "all using void closure should fail" {
+    assert.throwsException { => (1..4).all { [1, 2].add(3) } }
   }
 
   test "map" {
@@ -86,6 +113,14 @@ describe "ranges" {
     const range = 0 .. 10
     const evenFiltered = range.filter({ elem => elem.even() })
     assert.equals([0, 2, 4, 6, 8, 10], evenFiltered)
+  }
+
+  test "filter using null should fail" {
+    assert.throwsException { => (1..4).filter(null) }
+  }
+
+  test "filter using void closure should fail" {
+    assert.throwsException { => (1..4).filter { [1, 2].add(3) } }
   }
 
   test "count" {
@@ -126,6 +161,14 @@ describe "ranges" {
     assert.equals(3, range2.min())
   }
 
+  test "min using null should fail" {
+    assert.throwsException { => (1..4).min(null) }
+  }
+
+  test "min using void closure should fail" {
+    assert.throwsException { => (1..4).min { [1, 2].add(3) } }
+  }
+
   test "max" {
     const range = -22 .. -3
     const range2 = 7 .. 3
@@ -149,6 +192,14 @@ describe "ranges" {
     const range = 1 .. 9
     const evenFound = range.find({ elem => elem.even() })
     assert.equals(2, evenFound)
+  }
+
+  test "find using null should fail" {
+    assert.throwsException { => (1..3).find(null) }
+  }
+
+  test "find using void closure should fail" {
+    assert.throwsException { => (1..4).find { [1, 2].add(3) } }
   }
 
   test "findOrValue" {
@@ -182,6 +233,14 @@ describe "ranges" {
     assert.equals(2, range.count({ elem => elem.even() }))
   }
 
+  test "count using null should fail" {
+    assert.throwsException { => (1..3).count(null) }
+  }
+
+  test "count using void closure should fail" {
+    assert.throwsException { => (1..3).count { [1, 2].add(3) } }
+  }
+
   test "filter step minus 3" {
     const range = 8 .. 1
     range.step(-3)
@@ -201,16 +260,20 @@ describe "ranges" {
     assert.throwsException { => (1..4).forEach(null) }
   }
 
-  test "filter using null should fail" {
-    assert.throwsException { => (1..4).filter(null) }
-  }
-
   test "map using null should fail" {
     assert.throwsException { => (1..4).map(null) }
   }
 
   test "any using null should fail" {
     assert.throwsException { => (1..4).any(null) }
+  }
+
+  test "max using void closure should fail" {
+    assert.throwsException { => (1..4).max { number => [1, 2].add(number) } }
+  }
+
+  test "max using null should fail" {
+    assert.throwsException { => (1..4).max(null) }
   }
 
   test "toString with default step, ascending order" {

--- a/test/sanity/basics/ranges/ranges.wtest
+++ b/test/sanity/basics/ranges/ranges.wtest
@@ -211,7 +211,7 @@ describe "ranges" {
   test "findOrElse" {
     var encontro = true
     const range = 1 .. 9
-    const valueNotFound = range.findOrElse({ elem => elem > 55 }, { encontro = false })
+    range.findOrElse({ elem => elem > 55 }, { encontro = false })
     assert.notThat(encontro)
   }
 

--- a/test/sanity/collections/collections.wtest
+++ b/test/sanity/collections/collections.wtest
@@ -12,6 +12,10 @@ describe "Collection test case" {
     assert.throwsException { => [1, 2].min(null) }
   }
 
+  test "min using void closure should fail" {
+    assert.throwsException { => [1, 2, 3].min { [1, 2].add(3) } }
+  }
+
   test "min without parameters - happy path" {
     assert.equals(2, numbers.min() )
   }
@@ -28,7 +32,11 @@ describe "Collection test case" {
     assert.equals('hi', greetings.minIfEmpty({ e => e.length() }, { 'lista vacia' }))
     assert.equals('lista vacia', [].minIfEmpty({ e => e.length() }, { 'lista vacia' }))
   }
-  
+
+  test "minIfEmpty using null should fail" {
+    assert.throwsException { => [1, 2, 3].minIfEmpty(null) }
+  }
+
   test "minIfEmptyNoArgs" {
     assert.equals(1, [3, 1, 2].minIfEmpty({ 99 }))
     assert.equals(99, [].minIfEmpty({ 99 }))
@@ -37,7 +45,11 @@ describe "Collection test case" {
   test "max with closure" {
     assert.equals('bonjour', greetings.max { e => e.length() })
   }
-  
+
+  test "max using void closure should fail" {
+    assert.throwsException { => [1, 2].max { number => [1, 2].add(number) } }
+  }
+
   test "max using null should fail" {
     assert.throwsException { => [1, 2].max(null) }
   }
@@ -67,6 +79,10 @@ describe "Collection test case" {
     assert.equals(99, [].maxIfEmpty({ 99 }))
   }
 
+  test "maxIfEmpty using null should fail" {
+    assert.throwsException { => [1, 2, 3].maxIfEmpty(null) }
+  }
+
   test "size" {
     assert.equals(3, numbers.size())
   }
@@ -75,6 +91,14 @@ describe "Collection test case" {
     assert.that(numbers.contains(22))
     assert.that(numbers.contains(2))
     assert.that(numbers.contains(10))
+  }
+
+  test "contains accepts null" {
+    assert.notThat(numbers.contains(null))
+  }
+
+  test "contains accepts void" {
+    assert.notThat(numbers.contains(void))
   }
 
   test "uniqueElement in a list with one element should return that element" {
@@ -97,6 +121,10 @@ describe "Collection test case" {
 
   test "any using null should fail" {
     assert.throwsException { => [1, 2].any(null) }
+  }
+
+  test "any using void closure should fail" {
+    assert.throwsException { => [1, 2, 3].any { [1, 2].add(3) } }
   }
 
   test "remove" {
@@ -136,7 +164,12 @@ describe "Collection test case" {
   }
   
   test "all using null should fail" {
-    assert.throwsException { [1, 2].all(null) }    }  
+    assert.throwsException { [1, 2].all(null) }
+  }
+
+  test "all using void closure should fail" {
+    assert.throwsException { => [1, 2, 3].all { [1, 2].add(3) } }
+  }
 
   test "filter" {
     const greaterThanFiveElements = numbers.filter({n => n > 5})
@@ -144,7 +177,12 @@ describe "Collection test case" {
   }
 
   test "filter using null should fail" {
-    assert.throwsException { [1, 2].filter(null) }    }
+    assert.throwsException { [1, 2].filter(null) }
+  }
+
+  test "filter using void closure should fail" {
+    assert.throwsException { => [1, 2].filter { [1, 2].add(3) } }
+  }
 
   test "map" {
     const halfs = numbers.map({n => n / 2})
@@ -153,6 +191,22 @@ describe "Collection test case" {
 
   test "map using null should fail" {
     assert.throwsException { [1, 2].map(null) }
+  }
+
+  test "map using void closure should fail" {
+    assert.throwsException { [1, 2].map({ number => [1, 2].add(number) }) }
+  }
+
+  test "fold" {
+    assert.equals(10, [1, 2, 3, 4].fold(0, { acum, total => acum + total }))
+  }
+
+  test "fold using null should fail" {
+    assert.throwsException { [1, 2].fold(0, null) }
+  }
+
+  test "fold using void closure should fail" {
+    assert.throwsException { [1, 2].fold(0, { acum, number => [1, 2].add(number) }) }
   }
 
   test "map returns a list" {
@@ -202,8 +256,20 @@ describe "Collection test case" {
     assert.throwsException { numbers.find { e => e > 1000 } }
   }
 
+  test "find using null should fail" {
+    assert.throwsException { => [1, 2, 3].find(null) }
+  }
+
+  test "find using void closure should fail" {
+    assert.throwsException { => [1, 2, 3].find { [1, 2].add(3) } }
+  }
+
   test "findOrElse" {
     assert.equals(50, numbers.findOrElse({ e => e > 1000}, { 50 }))
+  }
+
+  test "findOrElse using void closure should fail" {
+    assert.throwsException { => numbers.findOrElse({ number => [].add(2) }, { 0 })}
   }
 
   test "findOrDefault when element does not exist" {
@@ -223,9 +289,17 @@ describe "Collection test case" {
   test "count using null should fail" {
     assert.throwsException { numbers.count(null) }
   }
-  
+
+  test "count using void closure should fail" {
+    assert.throwsException { => [1, 2, 3].count { [1, 2].add(3) } }
+  }
+
   test "sum" {
     assert.equals(34, numbers.sum {n => n})
+  }
+
+  test "sum using void closure should fail" {
+    assert.throwsException { numbers.sum({ [1].add(2) }) }
   }
 
   test "sum using null should fail" {
@@ -331,6 +405,20 @@ describe "Collection test case" {
 
     assert.equals([], [].sortedBy{ a, b => a > b })
     assert.equals([], #{}.sortedBy{ a, b => a > b })    
-  }  
+  }
+
+  test "add null should work" {
+    const list = []
+    list.add(null)
+    assert.equals(1, list.size())
+  }
+
+  test "add void element should fail" {
+    assert.throwsException { => [].add(void) }
+  }
+
+  test "remove void element should fail" {
+    assert.throwsException { => [1, 2].remove(void) }
+  }
 
 }

--- a/test/sanity/collections/collections.wtest
+++ b/test/sanity/collections/collections.wtest
@@ -98,7 +98,7 @@ describe "Collection test case" {
   }
 
   test "contains accepts void" {
-    assert.notThat(numbers.contains(void))
+    assert.throwsException { =>  numbers.contains(void) }
   }
 
   test "uniqueElement in a list with one element should return that element" {

--- a/test/sanity/collections/collections.wtest
+++ b/test/sanity/collections/collections.wtest
@@ -97,8 +97,8 @@ describe "Collection test case" {
     assert.notThat(numbers.contains(null))
   }
 
-  test "contains accepts void" {
-    assert.throwsException { =>  numbers.contains(void) }
+  test "contains does not accept void values" {
+    assert.throwsException { =>  numbers.contains([1].add(2)) }
   }
 
   test "uniqueElement in a list with one element should return that element" {
@@ -414,11 +414,11 @@ describe "Collection test case" {
   }
 
   test "add void element should fail" {
-    assert.throwsException { => [].add(void) }
+    assert.throwsException { => [].add([1].add(2)) }
   }
 
   test "remove void element should fail" {
-    assert.throwsException { => [1, 2].remove(void) }
+    assert.throwsException { => [1, 2].remove([1].add(2)) }
   }
 
 }

--- a/test/sanity/collections/dictionaryTestCase.wtest
+++ b/test/sanity/collections/dictionaryTestCase.wtest
@@ -75,7 +75,7 @@ describe "dictionary test case" {
 
   test "remove void element should fail" {
     const mapaTelefonos = dictionaryFactory.mapaTelefonos()
-    assert.throwsException { => mapaTelefonos.remove(void) }
+    assert.throwsException { => mapaTelefonos.remove([1].add(2)) }
   }
 
   test "keys" {

--- a/test/sanity/collections/dictionaryTestCase.wtest
+++ b/test/sanity/collections/dictionaryTestCase.wtest
@@ -73,6 +73,11 @@ describe "dictionary test case" {
     assert.equals(2, mapaTelefonos.size())
   }
 
+  test "remove void element should fail" {
+    const mapaTelefonos = dictionaryFactory.mapaTelefonos()
+    assert.throwsException { => mapaTelefonos.remove(void) }
+  }
+
   test "keys" {
     const mapa = new Dictionary()
     mapa.put(4, "2142-5980")

--- a/test/sanity/collections/list.wtest
+++ b/test/sanity/collections/list.wtest
@@ -86,13 +86,21 @@ describe "List tests" {
     assert.equals([2], [2].reverse())
   }
    
-  test "printing duplicated elements"{
+  test "printing duplicated elements" {
     const l1 = [[3,5,2], [4,2,6]].flatten()
     assert.equals("[3, 5, 2, 4, 2, 6]", l1.toString())
     const l2 = [1,2,3].flatMap({x => [x, x * 2, x * 3]})
     assert.equals("[1, 2, 3, 2, 4, 6, 3, 6, 9]", l2.toString())
     const l3 = [1,1,1]
     assert.equals("[1, 1, 1]", l3.toString())
+  }
+ 
+  test "flatMap using null should fail" {
+    assert.throwsException { [1, 2].flatMap(null) }
+  }
+ 
+  test "flatMap using void closures should fail" {
+    assert.throwsException { [1, 2].flatMap({ number => [1, 2].add(number) }) }
   }
  
   test "equality case true" {
@@ -189,6 +197,10 @@ describe "List tests" {
 
   test "sortBy using null should fail" {
     assert.throwsException { [1, 2].sortBy(null) }
+  }
+
+  test "sortBy using void closure should fail" {
+    assert.throwsException { [1, 2].sortBy { a, b => [1, 2].add(a) } }
   }
 
   test "sortedBy" {
@@ -418,6 +430,5 @@ describe "List tests" {
     assert.equals([1, 2, 3].join("-"), "1-2-3")
     assert.equals([].join("-"), "")
   }
-
 
 }

--- a/test/sanity/collections/list.wtest
+++ b/test/sanity/collections/list.wtest
@@ -422,7 +422,7 @@ describe "List tests" {
   
   test "findOrElse - not found" {
     var encontro = true
-    const valueFound = numbers.findOrElse({ elem => elem > 100 }, { encontro = false })
+    numbers.findOrElse({ elem => elem > 100 }, { encontro = false })
     assert.notThat(encontro)
   }
 

--- a/test/sanity/collections/set.wtest
+++ b/test/sanity/collections/set.wtest
@@ -164,6 +164,18 @@ describe "set tests" {
     assert.equals(4, numbers.size())  
   }
 
+  test "filter" {
+    assert.equals(#{0, 2, 4, 6, 8, 10}, #{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}.filter { number => number.even() })
+  }
+
+  test "filter using null should fail" {
+    assert.throwsException { => #{1, 2}.filter(null) }
+  }
+
+  test "filter using void closure should fail" {
+    assert.throwsException { => #{1, 2}.filter { [1, 2].add(3) } }
+  }
+
   test "flatten" {
     assert.equals(#{1,2,3,4}, #{#{1, 2}, #{1, 3, 4}}.flatten())
     assert.equals(#{1,2, 3}, #{#{1, 2}, #{}, #{1, 2, 3}}.flatten())
@@ -195,10 +207,23 @@ describe "set tests" {
     assert.notThat(encontro)
   }
 
+  test "findOrElse using void closure should fail" {
+    assert.throwsException { => numbers.findOrElse({ number => [].add(2) }, { 0 })}
+  }
+
+
   test "max" {
     assert.equals(5, #{1, 5, 0, -8, 3}.max())
     assert.equals(5, #{5, 1, 0, -8, 3}.max())
     assert.equals(5, #{1, 0, -8, 3, 5}.max())
+  }
+
+  test "max using void closure should fail" {
+    assert.throwsException { => #{1, 2}.max { number => [1, 2].add(number) } }
+  }
+
+  test "max using null should fail" {
+    assert.throwsException { => #{1, 2}.max(null) }
   }
 
   test "clear" {
@@ -211,6 +236,46 @@ describe "set tests" {
   test "join" {
     assert.equals(#{1, 2, 3}.join("-"), "1-2-3")
     assert.equals(#{}.join("-"), "")
+  }
+
+  test "fold" {
+    assert.equals(10, #{1, 2, 3, 4}.fold(0, { acum, total => acum + total }))
+  }
+
+  test "fold using null should fail" {
+    assert.throwsException { #{1, 2}.fold(0, null) }
+  }
+
+  test "fold using void closure should fail" {
+    assert.throwsException { #{1, 2}.fold(0, { acum, number => [1, 2].add(number) }) }
+  }
+
+  test "add null should work" {
+    const set = #{}
+    set.add(null)
+    assert.equals(1, set.size())
+  }
+
+  test "add void element should fail" {
+    assert.throwsException { => #{}.add(void) }
+  }
+
+  test "remove void element should fail" {
+    assert.throwsException { => #{}.remove(void) }
+  }
+
+  test "contains" {
+    assert.that(numbers.contains(22))
+    assert.that(numbers.contains(2))
+    assert.that(numbers.contains(10))
+  }
+
+  test "contains accepts null" {
+    assert.notThat(numbers.contains(null))
+  }
+
+  test "contains accepts void" {
+    assert.notThat(numbers.contains(void))
   }
 
 }

--- a/test/sanity/collections/set.wtest
+++ b/test/sanity/collections/set.wtest
@@ -257,11 +257,11 @@ describe "set tests" {
   }
 
   test "add void element should fail" {
-    assert.throwsException { => #{}.add(void) }
+    assert.throwsException { => #{}.add([1].add(2)) }
   }
 
   test "remove void element should fail" {
-    assert.throwsException { => #{}.remove(void) }
+    assert.throwsException { => #{}.remove([1].add(2)) }
   }
 
   test "contains" {
@@ -274,8 +274,8 @@ describe "set tests" {
     assert.notThat(numbers.contains(null))
   }
 
-  test "contains accepts void" {
-    assert.throwsException { =>  numbers.contains(void) }
+  test "contains does not accept void" {
+    assert.throwsException { =>  numbers.contains([1].add(2)) }
   }
 
 }

--- a/test/sanity/collections/set.wtest
+++ b/test/sanity/collections/set.wtest
@@ -275,7 +275,7 @@ describe "set tests" {
   }
 
   test "contains accepts void" {
-    assert.notThat(numbers.contains(void))
+    assert.throwsException { =>  numbers.contains(void) }
   }
 
 }

--- a/test/sanity/collections/set.wtest
+++ b/test/sanity/collections/set.wtest
@@ -203,7 +203,7 @@ describe "set tests" {
   
   test "findOrElse - not found" {
     var encontro = true
-    const valueFound = #{1, 2, 3, 4}.findOrElse({ elem => elem > 100 }, { encontro = false })
+    #{1, 2, 3, 4}.findOrElse({ elem => elem > 100 }, { encontro = false })
     assert.notThat(encontro)
   }
 

--- a/test/validations/shouldNotUseVoidSingleton.wlk
+++ b/test/validations/shouldNotUseVoidSingleton.wlk
@@ -17,10 +17,12 @@ class Bird {
 mixin Growable {
   var property height = 100
 
+  method compare(anObject, anotherObject) = anObject === anotherObject
+
   method grow() {
     const originalValue = @Expect(code="shouldNotUseVoidSingleton", level="error", expectedOn="void") void
 
-    if (originalValue !== @Expect(code="shouldNotUseVoidSingleton", level="error", expectedOn="void") void) {
+    if (self.compare(originalValue, @Expect(code="shouldNotUseVoidSingleton", level="error", expectedOn="void") void)) {
       height = height + 10
     }
   }

--- a/test/validations/shouldNotUseVoidSingleton.wlk
+++ b/test/validations/shouldNotUseVoidSingleton.wlk
@@ -1,0 +1,27 @@
+object pepita {
+  const extraEnergy = @Expect(code="shouldNotUseVoidSingleton", level="error", expectedOn="void") void
+  
+  var property friend = new Bird(energy = @Expect(code="shouldNotUseVoidSingleton", level="error", expectedOn="void") void)
+
+  method normalEnergy() = extraEnergy - 100
+}
+
+class Bird {
+  var property energy = 100
+
+  method fly() {
+    return @Expect(code="shouldNotUseVoidSingleton", level="error", expectedOn="void") void
+  }
+}
+
+mixin Growable {
+  var property height = 100
+
+  method grow() {
+    const originalValue = @Expect(code="shouldNotUseVoidSingleton", level="error", expectedOn="void") void
+
+    if (originalValue !== @Expect(code="shouldNotUseVoidSingleton", level="error", expectedOn="void") void) {
+      height = height + 10
+    }
+  }
+}

--- a/test/validations/shouldNotUseVoidSingleton2.wtest
+++ b/test/validations/shouldNotUseVoidSingleton2.wtest
@@ -1,0 +1,14 @@
+describe "a group of tests" {
+  const unwanted = @Expect(code="shouldNotUseVoidSingleton", level="error", expectedOn="void") void
+
+  method fly() {
+    return @Expect(code="shouldNotUseVoidSingleton", level="error", expectedOn="void") void
+  }
+
+  test "some test" {
+    const someVariable = @Expect(code="shouldNotUseVoidSingleton", level="error", expectedOn="void") void
+
+    assert.equals(someVariable, @Expect(code="shouldNotUseVoidSingleton", level="error", expectedOn="void") void)
+    assert.equals(someVariable, unwanted)
+  }
+}

--- a/test/validations/shouldNotUseVoidSingleton3.wpgm
+++ b/test/validations/shouldNotUseVoidSingleton3.wpgm
@@ -2,4 +2,6 @@ program myProgram {
   const unwanted = @Expect(code="shouldNotUseVoidSingleton", level="error", expectedOn="void") void
 
   console.println(unwanted)
+
+  console.println(@Expect(code="shouldNotUseVoidSingleton", level="error", expectedOn="void") void)
 }

--- a/test/validations/shouldNotUseVoidSingleton3.wpgm
+++ b/test/validations/shouldNotUseVoidSingleton3.wpgm
@@ -1,0 +1,5 @@
+program myProgram {
+  const unwanted = @Expect(code="shouldNotUseVoidSingleton", level="error", expectedOn="void") void
+
+  console.println(unwanted)
+}


### PR DESCRIPTION
Tomando el trabajo de @nmigueles para #208 , traje de wollok-ts-cli el método que sanitiza un stack trace para de paso resolver 

1. https://github.com/uqbar-project/wollok-ts/issues/274
2. https://github.com/uqbar-project/wollok-ts/issues/268

Una de las cosas que hice fue revisar de paso todos los usos de closures en Set, List, Collection, Range y Dictionary. En general revisé

- [x] map
- [x] flatMap
- [x] sum
- [x] max
- [x] maxIfEmpty
- [x] min 
- [x] minIfEmpty
- [x] all
- [x] any
- [x] find
- [x] count
- [x] sum
- [x] filter

de las implementaciones en Wollok, más otros métodos implementados en TS.

En Range acomodé la implementación de `asList` que me asegura que todos los métodos de esta clase deleguen en List (así comparten las mismas validaciones).

3. Agregué también sanity tests para especificar el contrato de lo que nosotros creemos que debería tirar error para implementaciones futuras, incluyendo algunas validaciones que incorporé en TS (como parámetros "void" o "null" que faltaban chequear).

4. Como en el recorrido del PR surgió la idea de no permitir el uso del wko `void`, agregué un mensaje para el validador y 3 archivos que chequean que no uses void en un programa, archivo de test o wlk.

