### PR TITLE
Fix shouldUseOverrideKeyword para properties

### DIFF
--- a/test/validations/shouldUseOverrideKeyword.wlk
+++ b/test/validations/shouldUseOverrideKeyword.wlk
@@ -21,3 +21,17 @@ class SomeSubClass inherits SomeSuperClass {
   @Expect(code="shouldUseOverrideKeyword", level="warning")
   method someMethod() = 2
 }
+
+class A { method m() }
+class B inherits A {
+  const property m // Allowed because m is a property
+}
+
+class C {
+  const property value = 0
+}
+
+class D inherits C {
+  @Expect(code="shouldUseOverrideKeyword", level="warning")
+  method value() = 1
+}


### PR DESCRIPTION
El [issue](https://github.com/uqbar-project/wollok-ts/issues/264) ocurre por reportar un error en una subclase que define una property con la cual resuelve la implementación de un método abstracto de una superclase.
