### PR TITLE
Fix flatten

### DIFF
--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -799,11 +799,18 @@ class Collection {
   method contains(element) = self.any {one => element == one }
 
   /**
-   * Flattens a collection of collections
+   * Flattens a collection of collections. 
+   *
+   * It always returns a list, because the elements in the resulting list could be duplicated.
+   * If you need to remove the duplicates, you can take the result and send asSet() message to it.
    *
    * Example:
    *     [ [1, 2], [3], [4, 0], [] ].flatten()
    *       => Answers [1, 2, 3, 4, 0]
+   *
+   *     #{ [1, 2], [1], [2, 3], [] }.flatten()
+   *       => Answers [1, 2, 1, 2, 3]
+   
    *
    */
   method flatten() = self.flatMap { it => it }

--- a/test/sanity/collections/set.wtest
+++ b/test/sanity/collections/set.wtest
@@ -177,13 +177,13 @@ describe "set tests" {
   }
 
   test "flatten" {
-    assert.equals(#{1,2,3,4}, #{#{1, 2}, #{1, 3, 4}}.flatten())
-    assert.equals(#{1, 2, 3}, #{#{1, 2}, #{}, #{1, 2, 3}}.flatten())
+    assert.equals([1, 2, 1, 3, 4], #{#{1, 2}, #{1, 3, 4}}.flatten())
+    assert.equals([1, 2, 1, 2, 3], #{#{1, 2}, #{}, #{1, 2, 3}}.flatten())
   }
 
   test "flatten for empty sets" {
-    assert.equals(#{}, #{}.flatten())
-    assert.equals(#{}, #{#{}}.flatten())
+    assert.equals([], #{}.flatten())
+    assert.equals([], #{#{}}.flatten())
   }
 
   test "flatMap" {


### PR DESCRIPTION
Arregla tests que se rompieron cuando mergeé el PR de flatMap porque flatten delega en flatMap así que ahora en los sets el flatten aplana formando una lista. De paso mejora la documentación de flatten.