### PR TITLE
POC unicode identifiers

### DIFF
--- a/test/sanity/basics/unicode.wtest
+++ b/test/sanity/basics/unicode.wtest
@@ -19,7 +19,7 @@ object ñandú {
 describe "pingüinos y ñandúes" {
   test "serán amados por Jorge" {
     const animales = [pingũino, ñandú]
-    const jorgelín = new Niño(nombre = "Jorge")
+    const jorgelín = new Niño(nombre = "Jorgelín Viñas")
     assert.equals(animales, animales.filter { animal => jorgelín.amó(animal) })
   }
 }

--- a/test/sanity/basics/unicode.wtest
+++ b/test/sanity/basics/unicode.wtest
@@ -1,10 +1,14 @@
 class Niño {
-  var nombre = ""
+  var property nombre = ""
   var años = 5
   method cumplirAños() {
     años = años + 1
   }
   method amó(animal) = animal.esBueno()
+}
+
+class Ñoqui {
+  var property pasta = true
 }
 
 object pingũino {
@@ -21,5 +25,7 @@ describe "pingüinos y ñandúes" {
     const animales = [pingũino, ñandú]
     const jorgelín = new Niño(nombre = "Jorgelín Viñas", años = 10)
     assert.equals(animales, animales.filter { animal => jorgelín.amó(animal) })
+    assert.equals("Jorgelín Viñas", jorgelín.nombre())
+    assert.that(new Ñoqui().pasta())
   }
 }

--- a/test/sanity/basics/unicode.wtest
+++ b/test/sanity/basics/unicode.wtest
@@ -19,7 +19,7 @@ object ñandú {
 describe "pingüinos y ñandúes" {
   test "serán amados por Jorge" {
     const animales = [pingũino, ñandú]
-    const jorgelín = new Niño(nombre = "Jorgelín Viñas")
+    const jorgelín = new Niño(nombre = "Jorgelín Viñas", años = 10)
     assert.equals(animales, animales.filter { animal => jorgelín.amó(animal) })
   }
 }

--- a/test/sanity/basics/unicode.wtest
+++ b/test/sanity/basics/unicode.wtest
@@ -1,0 +1,25 @@
+class Niño {
+  var nombre = ""
+  var años = 5
+  method cumplirAños() {
+    años = años + 1
+  }
+  method amó(animal) = animal.esBueno()
+}
+
+object pingũino {
+  method esBueno() = true
+}
+
+object ñandú {
+  const ñoño = false
+  method esBueno() = !ñoño
+}
+
+describe "pingüinos y ñandúes" {
+  test "serán amados por Jorge" {
+    const animales = [pingũino, ñandú]
+    const jorgelín = new Niño(nombre = "Jorge")
+    assert.equals(animales, animales.filter { animal => jorgelín.amó(animal) })
+  }
+}

--- a/test/validations/nameShouldBeginWithLowercase.wlk
+++ b/test/validations/nameShouldBeginWithLowercase.wlk
@@ -32,4 +32,4 @@ object pepitaArgenta {
 }
 
 @NotExpect(code="nameShouldBeginWithLowercase", level="warning")
-object área {}
+object ñoquis {}

--- a/test/validations/nameShouldBeginWithLowercase.wlk
+++ b/test/validations/nameShouldBeginWithLowercase.wlk
@@ -21,3 +21,15 @@ object pepita {
   }
 }
 
+object pepitaArgenta {
+  @NotExpect(code="nameShouldBeginWithLowercase", level="warning")
+  var property éxtasis = false
+  @NotExpect(code="nameShouldBeginWithLowercase", level="warning")
+  var property ñoña = false
+
+  @NotExpect(code="nameShouldBeginWithLowercase", level="warning")
+  method últimaVezEstabaBien() = !ñoña && !éxtasis
+}
+
+@NotExpect(code="nameShouldBeginWithLowercase", level="warning")
+object área {}

--- a/test/validations/nameShouldBeginWithUppercase.wlk
+++ b/test/validations/nameShouldBeginWithUppercase.wlk
@@ -8,3 +8,9 @@ class MockingBird inherits bird {}
 
 @Expect(code="nameShouldBeginWithUppercase", level="warning", expectedOn="flies")
 mixin flies {}
+
+@NotExpect(code="nameShouldBeginWithUppercase", level="warning")
+class Área {}
+
+@NotExpect(code="nameShouldBeginWithUppercase", level="warning")
+class Medida inherits Área {}


### PR DESCRIPTION
Este PR acompaña el trabajo que viene haciendo @nmigueles en https://github.com/uqbar-project/wollok-ts/pull/317.

Yo creo que podemos pedir que sea parte de la especificación bancarse caracteres Unicode, al menos los de lengua hispana (eñes y tildes).
