### PR TITLE
#86 #212 ceiling and floor and roundDown roundUp sugar implementation fix.

### DIFF
--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -2043,11 +2043,23 @@ class Number {
    *
    * Example:
    *     1.223445.roundUp(3)  ==> 1.224
-   *     -1.223445.roundUp(3) ==> -1.224
+   *     -1.223445.roundUp(3) ==> -1.222 //Should not be -1.224, beacause is smaller than -1.223, -1.222 is greater than -1.223
    *     14.6165.roundUp(3)   ==> 14.617
    *     5.roundUp(3)         ==> 5
    */
    method roundUp(_decimals) native
+
+ /**
+   * Rounds up self down to a certain amount of decimals.
+   * Amount of decimals must be a positive and integer value.
+   *
+   * Example:
+   *     1.223445.roundDown(3)  ==> 1.223
+   *     -1.223445.roundDown(3) ==> -1.224
+   *     14.6165.roundDown(3)   ==> 14.616
+   *     5.roundDown(3)         ==> 5
+   */
+   method roundDown(_decimals) native
 
   /**
    * Truncates self up to a certain amount of decimals.
@@ -2071,27 +2083,27 @@ class Number {
    *
    * Example:
    *     13.224.roundUp()  ==> 14
-   *     -13.224.roundUp() ==> -14 //SHOULD BE -12!
+   *     -13.224.roundUp() ==> -12
    *     15.942.roundUp()  ==> 16
    */
   method roundUp() = self.roundUp(0)
 
-  /**
-   * Answers the next integer smaller than self
+ /**
+   * Answers the previous integer greater than self
    *
    * Example:
-   *     13.224.roundDown()  ==> 13
-   *     -13.224.roundDown() ==> -14
-   *     15.942.roundDown()  ==> 15
+   *     13.224.roundUp()  ==> 13
+   *     -13.224.roundUp() ==> -14
+   *     15.942.roundUp()  ==> 15
    */
-  method roundDown() = self.floor() //self.roundDown(0)
+  method roundDown() = self.roundDown(0)
 
   /**
    * Returns the value of a number rounded to the nearest integer.
   **/
   method round() native
 
-  /**
+  /** 
    * Converts a decimal number into an integer truncating the decimal part to the same or lower value.
    *
    * Example:
@@ -2100,7 +2112,7 @@ class Number {
    *     (-5).floor() ==> Answers -5
    *     (-5.5).floor() ==> Answers -6
   **/
-  method floor() = if(self.isInteger()) self else { self.truncate(0) - if(self < 0) 1 else 0 } //Fix negative flooring, is like roundDown, roundUp is like ceiling.
+  method floor() = self.roundDown() //native
 
   /**
    * Converts a decimal number into an integer truncating the decimal part to the same or grater value.
@@ -2111,7 +2123,7 @@ class Number {
    *     (-5).ceiling() ==> Answers -5
    *     (-5.5).ceiling() ==> Answers -5
   **/
-  method ceiling() = if(self.isInteger()) self else { self.truncate(0) + if(self < 0) 0 else 1 } //Logic to fix negative ceiling. Is like roundUp
+  method ceil() = self.roundUp() //native
 
   /**
    * greater common divisor.

--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -2071,10 +2071,20 @@ class Number {
    *
    * Example:
    *     13.224.roundUp()  ==> 14
-   *     -13.224.roundUp() ==> -14
+   *     -13.224.roundUp() ==> -14 //SHOULD BE -12!
    *     15.942.roundUp()  ==> 16
    */
   method roundUp() = self.roundUp(0)
+
+  /**
+   * Answers the next integer smaller than self
+   *
+   * Example:
+   *     13.224.roundDown()  ==> 13
+   *     -13.224.roundDown() ==> -14
+   *     15.942.roundDown()  ==> 15
+   */
+  method roundDown() = self.floor() //self.roundDown(0)
 
   /**
    * Returns the value of a number rounded to the nearest integer.
@@ -2082,13 +2092,26 @@ class Number {
   method round() native
 
   /**
-   * Converts a decimal number into an integer truncating the decimal part.
+   * Converts a decimal number into an integer truncating the decimal part to the same or lower value.
    *
    * Example:
    *     5.5.floor() ==> Answers 5
    *     5.floor() ==> Answers 5
+   *     (-5).floor() ==> Answers -5
+   *     (-5.5).floor() ==> Answers -6
   **/
-  method floor() = self.truncate(0)
+  method floor() = if(self.isInteger()) self else { self.truncate(0) - if(self < 0) 1 else 0 } //Fix negative flooring, is like roundDown, roundUp is like ceiling.
+
+  /**
+   * Converts a decimal number into an integer truncating the decimal part to the same or grater value.
+   *
+   * Example:
+   *     5.5.ceiling() ==> Answers 6
+   *     5.ceiling() ==> Answers 5
+   *     (-5).ceiling() ==> Answers -5
+   *     (-5.5).ceiling() ==> Answers -5
+  **/
+  method ceiling() = if(self.isInteger()) self else { self.truncate(0) + if(self < 0) 0 else 1 } //Logic to fix negative ceiling. Is like roundUp
 
   /**
    * greater common divisor.

--- a/src/wollok/lang.wlk
+++ b/src/wollok/lang.wlk
@@ -2043,7 +2043,7 @@ class Number {
    *
    * Example:
    *     1.223445.roundUp(3)  ==> 1.224
-   *     -1.223445.roundUp(3) ==> -1.222 //Should not be -1.224, beacause is smaller than -1.223, -1.222 is greater than -1.223
+   *     (-1.223445).roundUp(3) ==> -1.223
    *     14.6165.roundUp(3)   ==> 14.617
    *     5.roundUp(3)         ==> 5
    */
@@ -2055,7 +2055,7 @@ class Number {
    *
    * Example:
    *     1.223445.roundDown(3)  ==> 1.223
-   *     -1.223445.roundDown(3) ==> -1.224
+   *     (-1.223445).roundDown(3) ==> -1.224
    *     14.6165.roundDown(3)   ==> 14.616
    *     5.roundDown(3)         ==> 5
    */
@@ -2083,7 +2083,7 @@ class Number {
    *
    * Example:
    *     13.224.roundUp()  ==> 14
-   *     -13.224.roundUp() ==> -12
+   *     (-13.224).roundUp() ==> -12
    *     15.942.roundUp()  ==> 16
    */
   method roundUp() = self.roundUp(0)
@@ -2092,9 +2092,9 @@ class Number {
    * Answers the previous integer greater than self
    *
    * Example:
-   *     13.224.roundUp()  ==> 13
-   *     -13.224.roundUp() ==> -14
-   *     15.942.roundUp()  ==> 15
+   *     13.224.roundDown()  ==> 13
+   *     (-13.224).roundDown() ==> -14
+   *     15.942.roundDown()  ==> 15
    */
   method roundDown() = self.roundDown(0)
 
@@ -2123,7 +2123,7 @@ class Number {
    *     (-5).ceiling() ==> Answers -5
    *     (-5.5).ceiling() ==> Answers -5
   **/
-  method ceil() = self.roundUp() //native
+  method ceil() = self.roundUp()
 
   /**
    * greater common divisor.

--- a/test/sanity/basics/numbers/roundingDecimals.wtest
+++ b/test/sanity/basics/numbers/roundingDecimals.wtest
@@ -5,7 +5,7 @@ describe "Decimal tests"{
 
   test "roundUp" {
     assert.equals(14, 13.224.roundUp())
-    assert.equals(-14, -13.224.roundUp())
+    assert.equals(-14, -13.224.roundUp()) //Should be -12
     assert.equals(16, 15.942.roundUp())
     assert.equals(15, 15.0.roundUp())
     assert.equals(-15, -15.0.roundUp())
@@ -30,6 +30,17 @@ describe "Decimal tests"{
     assert.equals(5, 5.1.floor())
     assert.equals(5, 5.5.floor())
     assert.equals(5, 5.9.floor())
+    assert.equals(-6, (-5.8).floor())
+    assert.equals(-5, -5.floor())
+  }
+
+  test "ceiling"{
+    assert.equals(5, 5.ceiling())
+    assert.equals(6, 5.1.ceiling())
+    assert.equals(6, 5.5.ceiling())
+    assert.equals(6, 5.9.ceiling())
+    assert.equals(-5, (-5.8).ceiling())
+    assert.equals(-5, -5.ceiling())
   }
 
   test "roundUp negative decimals throws error"{

--- a/test/sanity/basics/numbers/roundingDecimals.wtest
+++ b/test/sanity/basics/numbers/roundingDecimals.wtest
@@ -23,7 +23,7 @@ describe "Decimal tests"{
     assert.equals(-14, (-13.224).roundDown())
     assert.equals(15, 15.942.roundDown())
     assert.equals(15, 15.0.roundDown())
-    assert.equals(-15, -15.0.roundDown())
+    assert.equals(-15, (-15.0).roundDown())
   }
 
   test "roundDown Decimals"{

--- a/test/sanity/basics/numbers/roundingDecimals.wtest
+++ b/test/sanity/basics/numbers/roundingDecimals.wtest
@@ -5,7 +5,7 @@ describe "Decimal tests"{
 
   test "roundUp" {
     assert.equals(14, 13.224.roundUp())
-    assert.equals(-13, -13.224.roundUp()) //FAIL, but in Typescript Playground (oldest to newest verison 3.3.3 5.8.3) return the expected value!!! I'm goung bananas!
+    assert.equals(-13, -13.224.roundUp()) //FAIL, but in Typescript Playground (oldest to newest verison 3.3.3 5.8.3) return the expected value!!! I'm going bananas!
     assert.equals(16, 15.942.roundUp())
     assert.equals(15, 15.0.roundUp())
     assert.equals(-15, -15.0.roundUp())
@@ -13,14 +13,14 @@ describe "Decimal tests"{
 
   test "roundUp Decimals"{
     assert.equals(1.224, 1.223445.roundUp(3))
-    assert.equals(-1.223, -1.223445.roundUp(3)) //FAIL, but in Typescript Playground (oldest to newest verison 3.3.3 5.8.3) return the expected value!!! I'm goung bananas!
+    assert.equals(-1.223, -1.223445.roundUp(3)) //FAIL, but in Typescript Playground (oldest to newest verison 3.3.3 5.8.3) return the expected value!!! I'm going bananas!
     assert.equals(14.617, 14.6165.roundUp(3))
     assert.equals(14.6165, 14.6165.roundUp(6))
   }
 
   test "roundDown" {
     assert.equals(13, 13.224.roundDown())
-    assert.equals(-14, -13.224.roundDown()) //FAIL, but in Typescript Playground (oldest to newest verison 3.3.3 5.8.3) return the expected value!!! I'm goung bananas!
+    assert.equals(-14, -13.224.roundDown()) //FAIL, but in Typescript Playground (oldest to newest verison 3.3.3 5.8.3) return the expected value!!! I'm going bananas!
     assert.equals(15, 15.942.roundDown())
     assert.equals(15, 15.0.roundDown())
     assert.equals(-15, -15.0.roundDown())
@@ -28,7 +28,7 @@ describe "Decimal tests"{
 
   test "roundDown Decimals"{
     assert.equals(1.223, 1.223445.roundDown(3))
-    assert.equals(-1.224, -1.223445.roundDown(3)) //FAIL, but in Typescript Playground (oldest to newest verison 3.3.3 5.8.3) return the expected value!!! I'm goung bananas!
+    assert.equals(-1.224, -1.223445.roundDown(3)) //FAIL, but in Typescript Playground (oldest to newest verison 3.3.3 5.8.3) return the expected value!!! I'm going bananas!
     assert.equals(14.616, 14.6165.roundDown(3))
     assert.equals(14.6165, 14.6165.roundDown(6))
   }

--- a/test/sanity/basics/numbers/roundingDecimals.wtest
+++ b/test/sanity/basics/numbers/roundingDecimals.wtest
@@ -5,7 +5,7 @@ describe "Decimal tests"{
 
   test "roundUp" {
     assert.equals(14, 13.224.roundUp())
-    assert.equals(-13, -13.224.roundUp()) //FAIL, but in Typescript Playground (oldest to newest verison 3.3.3 5.8.3) return the expected value!!! I'm going bananas!
+    assert.equals(-13, (-13.224).roundUp())
     assert.equals(16, 15.942.roundUp())
     assert.equals(15, 15.0.roundUp())
     assert.equals(-15, -15.0.roundUp())
@@ -13,14 +13,14 @@ describe "Decimal tests"{
 
   test "roundUp Decimals"{
     assert.equals(1.224, 1.223445.roundUp(3))
-    assert.equals(-1.223, -1.223445.roundUp(3)) //FAIL, but in Typescript Playground (oldest to newest verison 3.3.3 5.8.3) return the expected value!!! I'm going bananas!
+    assert.equals(-1.223, (-1.223445).roundUp(3))
     assert.equals(14.617, 14.6165.roundUp(3))
     assert.equals(14.6165, 14.6165.roundUp(6))
   }
 
   test "roundDown" {
     assert.equals(13, 13.224.roundDown())
-    assert.equals(-14, -13.224.roundDown()) //FAIL, but in Typescript Playground (oldest to newest verison 3.3.3 5.8.3) return the expected value!!! I'm going bananas!
+    assert.equals(-14, (-13.224).roundDown())
     assert.equals(15, 15.942.roundDown())
     assert.equals(15, 15.0.roundDown())
     assert.equals(-15, -15.0.roundDown())
@@ -28,7 +28,7 @@ describe "Decimal tests"{
 
   test "roundDown Decimals"{
     assert.equals(1.223, 1.223445.roundDown(3))
-    assert.equals(-1.224, -1.223445.roundDown(3)) //FAIL, but in Typescript Playground (oldest to newest verison 3.3.3 5.8.3) return the expected value!!! I'm going bananas!
+    assert.equals(-1.224, (-1.223445).roundDown(3))
     assert.equals(14.616, 14.6165.roundDown(3))
     assert.equals(14.6165, 14.6165.roundDown(6))
   }
@@ -46,6 +46,7 @@ describe "Decimal tests"{
     assert.equals(5, 5.5.floor())
     assert.equals(5, 5.9.floor())
     assert.equals(-6, (-5.8).floor())
+    assert.equals(-14, (-13.224).floor())
     assert.equals(-5, -5.floor())
   }
 
@@ -55,6 +56,7 @@ describe "Decimal tests"{
     assert.equals(6, 5.5.ceil())
     assert.equals(6, 5.9.ceil())
     assert.equals(-5, (-5.8).ceil())
+    assert.equals(-13, (-13.224).ceil())
     assert.equals(-5, -5.ceil())
   }
 

--- a/test/sanity/basics/numbers/roundingDecimals.wtest
+++ b/test/sanity/basics/numbers/roundingDecimals.wtest
@@ -62,12 +62,12 @@ describe "Decimal tests"{
     assert.throwsException { 1.223445.roundUp(-3) }
   }
 
-  test "roundUp alphabetic decimals throws error"{
-    assert.throwsException { 1.223445.roundUp("B") }
-  }
-
   test "roundUp not integer decimals throws error"{
     assert.throwsException { 1.223445.roundUp(1.2) }
+  }
+
+  test "roundUp alphabetic decimals throws error"{
+    assert.throwsException { 1.223445.roundUp("B") }
   }
   
   test "integerRoundUp" {
@@ -87,7 +87,7 @@ describe "Decimal tests"{
   }
 
  test "roundDown negative decimals throws error"{
-    assert.throwsException { 1.223445.roundUp(-3) }
+    assert.throwsException { 1.223445.roundDown(-3) }
   }
 
   test "roundDown alphabetic decimals throws error"{

--- a/test/sanity/basics/numbers/roundingDecimals.wtest
+++ b/test/sanity/basics/numbers/roundingDecimals.wtest
@@ -47,7 +47,7 @@ describe "Decimal tests"{
     assert.equals(5, 5.9.floor())
     assert.equals(-6, (-5.8).floor())
     assert.equals(-14, (-13.224).floor())
-    assert.equals(-5, -5.floor())
+    assert.equals(-5, (-5).floor())
   }
 
   test "ceil"{
@@ -57,7 +57,7 @@ describe "Decimal tests"{
     assert.equals(6, 5.9.ceil())
     assert.equals(-5, (-5.8).ceil())
     assert.equals(-13, (-13.224).ceil())
-    assert.equals(-5, -5.ceil())
+    assert.equals(-5, (-5).ceil())
   }
 
   test "roundUp negative decimals throws error"{

--- a/test/sanity/basics/numbers/roundingDecimals.wtest
+++ b/test/sanity/basics/numbers/roundingDecimals.wtest
@@ -5,7 +5,7 @@ describe "Decimal tests"{
 
   test "roundUp" {
     assert.equals(14, 13.224.roundUp())
-    assert.equals(-14, -13.224.roundUp()) //Should be -12
+    assert.equals(-13, -13.224.roundUp()) //FAIL, but in Typescript Playground (oldest to newest verison 3.3.3 5.8.3) return the expected value!!! I'm goung bananas!
     assert.equals(16, 15.942.roundUp())
     assert.equals(15, 15.0.roundUp())
     assert.equals(-15, -15.0.roundUp())
@@ -13,9 +13,24 @@ describe "Decimal tests"{
 
   test "roundUp Decimals"{
     assert.equals(1.224, 1.223445.roundUp(3))
-    assert.equals(-1.224, -1.223445.roundUp(3))
+    assert.equals(-1.223, -1.223445.roundUp(3)) //FAIL, but in Typescript Playground (oldest to newest verison 3.3.3 5.8.3) return the expected value!!! I'm goung bananas!
     assert.equals(14.617, 14.6165.roundUp(3))
     assert.equals(14.6165, 14.6165.roundUp(6))
+  }
+
+  test "roundDown" {
+    assert.equals(13, 13.224.roundDown())
+    assert.equals(-14, -13.224.roundDown()) //FAIL, but in Typescript Playground (oldest to newest verison 3.3.3 5.8.3) return the expected value!!! I'm goung bananas!
+    assert.equals(15, 15.942.roundDown())
+    assert.equals(15, 15.0.roundDown())
+    assert.equals(-15, -15.0.roundDown())
+  }
+
+  test "roundDown Decimals"{
+    assert.equals(1.223, 1.223445.roundDown(3))
+    assert.equals(-1.224, -1.223445.roundDown(3)) //FAIL, but in Typescript Playground (oldest to newest verison 3.3.3 5.8.3) return the expected value!!! I'm goung bananas!
+    assert.equals(14.616, 14.6165.roundDown(3))
+    assert.equals(14.6165, 14.6165.roundDown(6))
   }
 
   test "truncate"{
@@ -34,13 +49,13 @@ describe "Decimal tests"{
     assert.equals(-5, -5.floor())
   }
 
-  test "ceiling"{
-    assert.equals(5, 5.ceiling())
-    assert.equals(6, 5.1.ceiling())
-    assert.equals(6, 5.5.ceiling())
-    assert.equals(6, 5.9.ceiling())
-    assert.equals(-5, (-5.8).ceiling())
-    assert.equals(-5, -5.ceiling())
+  test "ceil"{
+    assert.equals(5, 5.ceil())
+    assert.equals(6, 5.1.ceil())
+    assert.equals(6, 5.5.ceil())
+    assert.equals(6, 5.9.ceil())
+    assert.equals(-5, (-5.8).ceil())
+    assert.equals(-5, -5.ceil())
   }
 
   test "roundUp negative decimals throws error"{
@@ -51,6 +66,10 @@ describe "Decimal tests"{
     assert.throwsException { 1.223445.roundUp("B") }
   }
 
+  test "roundUp not integer decimals throws error"{
+    assert.throwsException { 1.223445.roundUp(1.2) }
+  }
+  
   test "integerRoundUp" {
     assert.equals(5, (10/2).roundUp(2))
   }
@@ -65,6 +84,38 @@ describe "Decimal tests"{
 
   test "doubleRoundUp" {
     assert.equals(1.3, (5/4).roundUp(1))
+  }
+
+ test "roundDown negative decimals throws error"{
+    assert.throwsException { 1.223445.roundUp(-3) }
+  }
+
+  test "roundDown alphabetic decimals throws error"{
+    assert.throwsException { 1.223445.roundDown("B") }
+  }
+
+  test "roundDown not integer decimals throws error"{
+    assert.throwsException { 1.223445.roundDown(1.2) }
+  }
+
+  test "integerRoundDown" {
+    assert.equals(5, (10/2).roundDown(2))
+  }
+
+  test "roundDownUsingNull" {
+    assert.throwsException({ (10/2).roundDown(null) })
+  }
+
+  test "roundDownFail" {
+    assert.throwsException({ (10/2).roundDown("a") })
+  }
+
+  test "doubleRoundDown" {
+    assert.equals(1.2, (5/4).roundDown(1))
+  }
+
+  test "truncate negative decimals throws error"{
+    assert.throwsException { 1.223445.truncate(-3) }
   }
 
   test "truncate negative decimals throws error"{

--- a/test/sanity/basics/numbers/roundingDecimals.wtest
+++ b/test/sanity/basics/numbers/roundingDecimals.wtest
@@ -126,6 +126,10 @@ describe "Decimal tests"{
     assert.throwsException { 1.223445.truncate("A") }
   }
 
+  test "truncate not integer decimals throws error"{
+    assert.throwsException { 1.223445.truncate(1.2) }
+  }
+
   test "integerTruncate" {
     assert.equals(5, (10/2).truncate(2))
   }

--- a/test/sanity/game/game.wtest
+++ b/test/sanity/game/game.wtest
@@ -82,7 +82,7 @@ describe "Game" {
   test "While game is running center is an inmmutable position" {
     game.width(2)
     game.height(5)
-    game.running(true) //Check refactor is game var running remove setter method.
+    game.start()
    
     const center = game.center()
    


### PR DESCRIPTION
Floor should give in negative numbers with decimal parte a lower integer but only apply "truncate". 
Floor Example: 2.5 -> 3, 2.0 -> 2, -2 -> -2, -2.5 -> -3. But intead in current -2.5 gives 2.
roundUp() and roundDown() (0 digits) are renamed versions of ceiling and floor. The idea is to have both as a syntactic sugar.
Added ceil() function. 

Relacionado con el PR y branch TS:
https://github.com/uqbar-project/wollok-ts/pull/346
https://github.com/uqbar-project/wollok-ts/tree/Fix-%2386-%23212-floor-for-negative-numbers-and-ceiling