### PR TITLE
Add CI for language PRs

### DIFF
--- a/.github/workflows/wollok.ts.yml
+++ b/.github/workflows/wollok.ts.yml
@@ -18,11 +18,11 @@ jobs:
     - name: Read .nvmrc
       run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
       id: nvm
-      working-directory: wollok-ts
+      working-directory: ../wollok-ts
     - name: Use Node.js (.nvmrc)
       uses: actions/setup-node@v4
       with:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
     - name: run tests
-      run: npm run build && npm run test
+      run: ls -la .. && npm run build && npm run test
       working-directory: wollok-ts

--- a/.github/workflows/wollok.ts.yml
+++ b/.github/workflows/wollok.ts.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Wollok TS CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
+      with:
+        name: uqbar-project/wollok-ts
+        ref: ref/heads/master
+    - name: Read .nvmrc
+      run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+      working-directory: wollok-ts
+      id: nvm
+    - name: Use Node.js (.nvmrc)
+      uses: actions/setup-node@v4
+      with:
+        node-version: "${{ steps.nvm.outputs.NVMRC }}"
+      working-directory: wollok-ts
+    - name: run tests
+      run: npm run build && npm run test
+      working-directory: wollok-ts

--- a/.github/workflows/wollok.ts.yml
+++ b/.github/workflows/wollok.ts.yml
@@ -26,5 +26,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
+    - run: npm ci        
     - name: run tests
       run: npm run build && npm run test

--- a/.github/workflows/wollok.ts.yml
+++ b/.github/workflows/wollok.ts.yml
@@ -14,8 +14,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/checkout@v4
       with:
-        name: uqbar-project/wollok-ts
-        ref: ref/heads/master
+        repository: uqbar-project/wollok-ts
     - name: Read .nvmrc
       run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
       id: nvm

--- a/.github/workflows/wollok.ts.yml
+++ b/.github/workflows/wollok.ts.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         repository: uqbar-project/wollok-ts
     - name: copy nvm
-      run: cp wollok-ts/.nvmrc .
+      run: ls -lR . && cp wollok-ts/.nvmrc .
     - name: Read .nvmrc
       run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
       id: nvm
@@ -25,5 +25,5 @@ jobs:
       with:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
     - name: run tests
-      run: ls -la .. && npm run build && npm run test
+      run: npm run build && npm run test
       working-directory: wollok-ts

--- a/.github/workflows/wollok.ts.yml
+++ b/.github/workflows/wollok.ts.yml
@@ -15,7 +15,8 @@ jobs:
       with:
         repository: uqbar-project/wollok-ts
     - uses: actions/checkout@v4
-      path: language
+      with:
+        path: language
     - name: list folders
       run: ls -lR
     - name: Read .nvmrc

--- a/.github/workflows/wollok.ts.yml
+++ b/.github/workflows/wollok.ts.yml
@@ -18,13 +18,12 @@ jobs:
         ref: ref/heads/master
     - name: Read .nvmrc
       run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-      working-directory: wollok-ts
       id: nvm
+      working-directory: wollok-ts
     - name: Use Node.js (.nvmrc)
       uses: actions/setup-node@v4
       with:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
-      working-directory: wollok-ts
     - name: run tests
       run: npm run build && npm run test
       working-directory: wollok-ts

--- a/.github/workflows/wollok.ts.yml
+++ b/.github/workflows/wollok.ts.yml
@@ -12,11 +12,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/checkout@v4
       with:
         repository: uqbar-project/wollok-ts
-    - name: copy nvm
-      run: ls -lR . && cp wollok-ts/.nvmrc .
+    - uses: actions/checkout@v4
+      path: language
+    - name: list folders
+      run: ls -lR
     - name: Read .nvmrc
       run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
       id: nvm
@@ -26,4 +27,3 @@ jobs:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
     - name: run tests
       run: npm run build && npm run test
-      working-directory: wollok-ts

--- a/.github/workflows/wollok.ts.yml
+++ b/.github/workflows/wollok.ts.yml
@@ -15,10 +15,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         repository: uqbar-project/wollok-ts
+    - name: copy nvm
+      run: cp wollok-ts/.nvmrc .
     - name: Read .nvmrc
       run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
       id: nvm
-      working-directory: ../wollok-ts
     - name: Use Node.js (.nvmrc)
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/wollok.ts.yml
+++ b/.github/workflows/wollok.ts.yml
@@ -17,8 +17,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         path: language
-    - name: list folders
-      run: ls -lR
     - name: Read .nvmrc
       run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
       id: nvm

--- a/.github/workflows/wollok.ts.yml
+++ b/.github/workflows/wollok.ts.yml
@@ -14,6 +14,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         repository: uqbar-project/wollok-ts
+        ref: refs/heads/master
     - uses: actions/checkout@v4
       with:
         path: language

--- a/.github/workflows/wollok.ts.yml
+++ b/.github/workflows/wollok.ts.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Wollok TS CI
+name: Wollok TS
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Agregamos CI para language basado en wollok-ts. Tenemos que agregar el build como pre-condición pero que no sea obligatoria para mergear.

Lo que hace el PR es armar un build donde:
- primero checkouteamos wollok-ts (forzando a que sea master)
- luego hacemos un checkout de language y lo ubicamos en la carpeta language, como necesita wollok-ts
- npm ci descarga las dependencias y como tenemos language cargado no lo toca, justo lo que queremos
- después hacemos build y ejecutamos los tests

Lo que sigue es configurar que este build aparezca dentro de los PRs como opcional para que avise si pasa o no.

Fix #144 
