### PR TITLE
Permitir Catch vacios en el validador y agrego shx a los comandos

### DIFF
--- a/test/validations/shouldNotBeEmpty1.wtest
+++ b/test/validations/shouldNotBeEmpty1.wtest
@@ -19,9 +19,16 @@ object objectWithEmptyMethod {
 
   }
 
-  method methodWithEmptyTryCatch() {
+  method methodWithEmptyTry() {
     try @Expect(code="shouldNotBeEmpty", level="warning") {
-    } catch e @Expect(code="shouldNotBeEmpty", level="warning") {
+    } catch e {
+      console.println(e)
+    }
+  }
+    method methodWithEmptyCatch() {
+    try {
+      console.println(1)
+    } catch e @NotExpect(code="shouldNotBeEmpty") {
     }
   }
 }


### PR DESCRIPTION
Separo los casos del try-catch, donde uno valida que el `Body` del `Try` no pueda ser vacio y otro valida que se permita que el `Catch` este vacio.